### PR TITLE
Fix issue 36 sorting for views and local files

### DIFF
--- a/src/usdb_syncer/gui/song_table/song_table.py
+++ b/src/usdb_syncer/gui/song_table/song_table.py
@@ -11,7 +11,7 @@ from PySide6.QtWidgets import QAbstractItemView, QHeaderView, QTableView
 
 from usdb_syncer import SongId
 from usdb_syncer.gui.song_table.sort_filter_proxy_model import SortFilterProxyModel
-from usdb_syncer.gui.song_table.table_model import TableModel
+from usdb_syncer.gui.song_table.table_model import CustomRole, TableModel
 from usdb_syncer.logger import get_logger
 from usdb_syncer.notes_parser import SongTxt
 from usdb_syncer.song_data import SongData
@@ -29,6 +29,7 @@ class SongTable:
         self._model = TableModel(parent)
         self._proxy_model = SortFilterProxyModel(parent)
         self._proxy_model.setSourceModel(self._model)
+        self._proxy_model.setSortRole(CustomRole.SORT)
         self._view.setModel(self._proxy_model)
         self._view.setSelectionMode(QAbstractItemView.SelectionMode.ExtendedSelection)
 

--- a/src/usdb_syncer/gui/song_table/table_model.py
+++ b/src/usdb_syncer/gui/song_table/table_model.py
@@ -23,6 +23,7 @@ class CustomRole(int, Enum):
     """Custom values expanding Qt.QItemDataRole."""
 
     ALL_DATA = 100
+    SORT     = 101
 
 
 class TableModel(QAbstractTableModel):
@@ -76,6 +77,8 @@ class TableModel(QAbstractTableModel):
             return self.songs[index.row()].decoration_data(index.column())
         if role == CustomRole.ALL_DATA:
             return self.songs[index.row()]
+        if role == CustomRole.SORT:
+            return self.songs[index.row()].sort_data(index.column())
         return None
 
     def headerData(

--- a/src/usdb_syncer/song_data.py
+++ b/src/usdb_syncer/song_data.py
@@ -5,7 +5,6 @@ plus information about locally existing files.
 from __future__ import annotations
 
 from functools import cache
-from typing import Any
 
 import attrs
 from PySide6.QtGui import QIcon
@@ -146,7 +145,7 @@ class SongData:
             case _ as unreachable:
                 assert_never(unreachable)
 
-    def sort_data(self, column: int) -> Any | None:
+    def sort_data(self, column: int) -> int | str | bool:
         col = Column(column)
         match col:
             case Column.SONG_ID:

--- a/src/usdb_syncer/song_data.py
+++ b/src/usdb_syncer/song_data.py
@@ -5,6 +5,7 @@ plus information about locally existing files.
 from __future__ import annotations
 
 from functools import cache
+from typing import Any
 
 import attrs
 from PySide6.QtGui import QIcon
@@ -142,6 +143,38 @@ class SongData:
                 return optional_check_icon(self.local_files.cover)
             case Column.BACKGROUND:
                 return optional_check_icon(self.local_files.background)
+            case _ as unreachable:
+                assert_never(unreachable)
+
+    def sort_data(self, column: int) -> Any | None:
+        col = Column(column)
+        match col:
+            case Column.SONG_ID:
+                return self.data.song_id.value
+            case Column.ARTIST:
+                return self.data.artist
+            case Column.TITLE:
+                return self.data.title
+            case Column.LANGUAGE:
+                return self.data.language
+            case Column.EDITION:
+                return self.data.edition
+            case Column.GOLDEN_NOTES:
+                return self.data.golden_notes
+            case Column.RATING:
+                return self.data.rating
+            case Column.VIEWS:
+                return self.data.views
+            case Column.TXT:
+                return self.local_files.txt
+            case Column.AUDIO:
+                return self.local_files.audio
+            case Column.VIDEO:
+                return self.local_files.video
+            case Column.COVER:
+                return self.local_files.cover
+            case Column.BACKGROUND:
+                return self.local_files.background
             case _ as unreachable:
                 assert_never(unreachable)
 


### PR DESCRIPTION
This fixes https://github.com/bohning/usdb_syncer/issues/36

Sorting behavior for other columns should remain unchanged.

Please let me know what you think about overriding the `QSortFilterProxyModel`'s `lessThan` method instead of the solution in the initial PR. It would facilitate locale aware sorting which would be especially useful for the title and artist columns.
An example for this is given in the [docs](https://doc.qt.io/qtforpython-5/PySide2/QtCore/QSortFilterProxyModel.html#sorting) at the bottom of the big code block in the section about sorting.