### PR TITLE
Fix songs that are entirely ALL CAPS.

### DIFF
--- a/src/usdb_syncer/notes_parser.py
+++ b/src/usdb_syncer/notes_parser.py
@@ -254,6 +254,11 @@ class Tracks:
     def lyrics(self) -> str:
         return "".join(note.text for note in self.all_notes())
 
+    def is_all_caps(self) -> bool:
+        return not any(
+            char.islower() for note in self.all_notes() for char in note.text
+        )
+
     def fix_line_breaks(self) -> None:
         for track in self.all_tracks():
             fix_line_breaks(track)
@@ -304,7 +309,7 @@ class Tracks:
             line.notes[-1].right_trim_text_and_add_space()
 
     def fix_all_caps(self) -> None:
-        if all(note.text.isupper() for note in self.all_notes()):
+        if self.is_all_caps():
             for note in self.all_notes():
                 note.text = note.text.lower()
             self.fix_first_words_capitalization()
@@ -313,15 +318,12 @@ class Tracks:
         for line in self.all_lines():
             # capitalize first capitalizable character
             # e.g. "“¿que horas son?”" -> "“¿Que horas son?”"
-            text = ""
             for char in line.notes[0].text:
                 if char != char.upper():
                     line.notes[0].text = line.notes[0].text.replace(
                         char, char.upper(), 1
                     )
                     break
-
-            line.notes[0].text = text
 
 
 def _player_lines(lines: list[str], logger: Log) -> list[Line]:

--- a/src/usdb_syncer/notes_parser.py
+++ b/src/usdb_syncer/notes_parser.py
@@ -314,7 +314,7 @@ class Tracks:
     def fix_first_words_capitalization(self) -> None:
         for line in self.all_lines():
             # capitalize first capitalizable character
-            # e.g. "“¿que horas son?”" -> "“¿Que horas son?”"
+            # e.g. '"what time is it?"' -> '"What time is it?"'
             for char in line.notes[0].text:
                 if char != char.upper():
                     line.notes[0].text = line.notes[0].text.replace(

--- a/src/usdb_syncer/notes_parser.py
+++ b/src/usdb_syncer/notes_parser.py
@@ -315,7 +315,9 @@ class Tracks:
             # e.g. "“¿que horas son?”" -> "“¿Que horas son?”"
             text = ""
             for char_index, char in enumerate(line.notes[0].text):
-                if char == char.capitalize():
+                if char != char.upper():
+                    line.notes[0].text = line.notes[0].text.replace(char, char.upper(), 1)
+                    break
                     text = text + char
                 else:
                     text = (

--- a/src/usdb_syncer/notes_parser.py
+++ b/src/usdb_syncer/notes_parser.py
@@ -251,9 +251,6 @@ class Tracks:
             for note in line.notes:
                 yield note
 
-    def lyrics(self) -> str:
-        return "".join(note.text for note in self.all_notes())
-
     def is_all_caps(self) -> bool:
         return not any(
             char.islower() for note in self.all_notes() for char in note.text

--- a/src/usdb_syncer/notes_parser.py
+++ b/src/usdb_syncer/notes_parser.py
@@ -304,7 +304,7 @@ class Tracks:
             line.notes[-1].right_trim_text_and_add_space()
 
     def fix_all_caps(self) -> None:
-        if self.lyrics().isupper():
+        if all(note.text.isupper() for note in self.all_notes()):
             for note in self.all_notes():
                 note.text = note.text.lower()
             self.fix_first_words_capitalization()

--- a/src/usdb_syncer/notes_parser.py
+++ b/src/usdb_syncer/notes_parser.py
@@ -314,14 +314,10 @@ class Tracks:
             # capitalize first capitalizable character
             # e.g. "“¿que horas son?”" -> "“¿Que horas son?”"
             text = ""
-            for char_index, char in enumerate(line.notes[0].text):
+            for char in line.notes[0].text:
                 if char != char.upper():
-                    line.notes[0].text = line.notes[0].text.replace(char, char.upper(), 1)
-                    break
-                    text = text + char
-                else:
-                    text = (
-                        text + char.capitalize() + line.notes[0].text[char_index + 1 :]
+                    line.notes[0].text = line.notes[0].text.replace(
+                        char, char.upper(), 1
                     )
                     break
 


### PR DESCRIPTION
Lyrics in ALL CAPS is considered as shouting and therefore discouraged/bad style. Thus, if a song’s lyrics are entirely (!) ALL CAPS, they are all changed to lowercase and then the first word (more precisely the first capitalizable letter of the first word) of each line is capitalized again.

The only downside is that names/nouns that should be capitalized are then lowercase, but this should only concern a handful of words, so fixing this manually only takes a small effort.

Good test cases are e.g.:
http://usdb.animux.de/index.php?link=detail&id=9417
http://usdb.animux.de/index.php?link=detail&id=18539
http://usdb.animux.de/index.php?link=detail&id=21467
http://usdb.animux.de/index.php?link=detail&id=22046