### PR TITLE
Extend audio and video settings.

### DIFF
--- a/src/usdb_syncer/download_options.py
+++ b/src/usdb_syncer/download_options.py
@@ -18,6 +18,7 @@ class AudioOptions:
     """Settings regarding the audio file to be downloaded."""
 
     format: settings.AudioFormat
+    bitrate: settings.AudioBitrate
 
     def ytdl_format(self) -> str:
         return self.format.ytdl_format()
@@ -92,7 +93,9 @@ def _txt_options() -> TxtOptions | None:
 def _audio_options() -> AudioOptions | None:
     if not settings.get_audio():
         return None
-    return AudioOptions(format=settings.get_audio_format())
+    return AudioOptions(
+        format=settings.get_audio_format(), bitrate=settings.get_audio_bitrate()
+    )
 
 
 def _video_options() -> VideoOptions | None:

--- a/src/usdb_syncer/gui/forms/SettingsDialog.ui
+++ b/src/usdb_syncer/gui/forms/SettingsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>374</width>
-    <height>310</height>
+    <width>491</width>
+    <height>409</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -234,6 +234,20 @@
           </property>
           <property name="toolTip">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;M4A:&lt;/span&gt; Best quality and speed. Compatible with UltraStar Deluxe, Vocaluxe, Performous and UltraStar World Party.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;MP3: &lt;/span&gt;Worst quality and speed. Full compatibility.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Bitrate:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="comboBox_audio_bitrate">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the audio file is reencoded, the selected bitrate will be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
          </widget>
         </item>

--- a/src/usdb_syncer/gui/settings_dialog.py
+++ b/src/usdb_syncer/gui/settings_dialog.py
@@ -24,6 +24,8 @@ class SettingsDialog(Ui_Dialog, QDialog):
             self.comboBox_line_endings.addItem(str(newline), newline)
         for container in settings.AudioFormat:
             self.comboBox_audio_format.addItem(str(container), container)
+        for bitrate in settings.AudioBitrate:
+            self.comboBox_audio_bitrate.addItem(str(bitrate), bitrate)
         for browser in settings.Browser:
             self.comboBox_browser.addItem(QIcon(browser.icon()), str(browser), browser)
         for video_container in settings.VideoContainer:
@@ -52,6 +54,9 @@ class SettingsDialog(Ui_Dialog, QDialog):
         self.comboBox_audio_format.setCurrentIndex(
             self.comboBox_audio_format.findData(settings.get_audio_format())
         )
+        self.comboBox_audio_bitrate.setCurrentIndex(
+            self.comboBox_audio_bitrate.findData(settings.get_audio_bitrate())
+        )
         self.groupBox_video.setChecked(settings.get_video())
         self.comboBox_videocontainer.setCurrentIndex(
             self.comboBox_videocontainer.findData(settings.get_video_format())
@@ -78,6 +83,7 @@ class SettingsDialog(Ui_Dialog, QDialog):
         settings.set_newline(self.comboBox_line_endings.currentData())
         settings.set_audio(self.groupBox_audio.isChecked())
         settings.set_audio_format(self.comboBox_audio_format.currentData())
+        settings.set_audio_bitrate(self.comboBox_audio_bitrate.currentData())
         settings.set_video(self.groupBox_video.isChecked())
         settings.set_video_format(self.comboBox_videocontainer.currentData())
         settings.set_video_format_new(self.comboBox_videoencoder.currentData())

--- a/src/usdb_syncer/resource_dl.py
+++ b/src/usdb_syncer/resource_dl.py
@@ -82,7 +82,7 @@ def download_video(
     if isinstance(options, AudioOptions):
         postprocessor = {
             "key": "FFmpegExtractAudio",
-            "preferredquality": "320",
+            "preferredquality": options.bitrate.ytdl_format(),
             "preferredcodec": options.format.value,
         }
         ydl_opts["postprocessors"] = [postprocessor]

--- a/src/usdb_syncer/settings.py
+++ b/src/usdb_syncer/settings.py
@@ -104,11 +104,11 @@ class AudioFormat(Enum):
 class AudioBitrate(Enum):
     """Audio bitrate."""
 
-    _128KBPS = "128 kbps"
-    _160KBPS = "160 kbps"
-    _192KBPS = "192 kbps"
-    _256KBPS = "256 kbps"
-    _320KBPS = "320 kbps"
+    KBPS_128 = "128 kbps"
+    KBPS_160 = "160 kbps"
+    KBPS_192 = "192 kbps"
+    KBPS_256 = "256 kbps"
+    KBPS_320 = "320 kbps"
 
     def __str__(self) -> str:
         return self.value
@@ -208,46 +208,46 @@ class VideoCodec(Enum):
 class VideoResolution(Enum):
     """Maximum video resolution."""
 
-    _2160P = "2160p"
-    _1440P = "1440p"
-    _1080P = "1080p"
-    _720P = "720p"
-    _480P = "480p"
-    _360P = "360p"
+    P2160 = "2160p"
+    P1440 = "1440p"
+    P1080 = "1080p"
+    P720 = "720p"
+    P480 = "480p"
+    P360 = "360p"
 
     def __str__(self) -> str:
         return self.value
 
     def width(self) -> int:
         match self:
-            case VideoResolution._2160P:
+            case VideoResolution.P2160:
                 return 3840
-            case VideoResolution._1440P:
+            case VideoResolution.P1440:
                 return 2560
-            case VideoResolution._1080P:
+            case VideoResolution.P1080:
                 return 1920
-            case VideoResolution._720P:
+            case VideoResolution.P720:
                 return 1280
-            case VideoResolution._480P:
+            case VideoResolution.P480:
                 return 854
-            case VideoResolution._360P:
+            case VideoResolution.P360:
                 return 640
             case _ as unreachable:
                 assert_never(unreachable)
 
     def height(self) -> int:
         match self:
-            case VideoResolution._2160P:
+            case VideoResolution.P2160:
                 return 2160
-            case VideoResolution._1440P:
+            case VideoResolution.P1440:
                 return 1440
-            case VideoResolution._1080P:
+            case VideoResolution.P1080:
                 return 1080
-            case VideoResolution._720P:
+            case VideoResolution.P720:
                 return 720
-            case VideoResolution._480P:
+            case VideoResolution.P480:
                 return 480
-            case VideoResolution._360P:
+            case VideoResolution.P360:
                 return 360
             case _ as unreachable:
                 assert_never(unreachable)
@@ -256,8 +256,8 @@ class VideoResolution(Enum):
 class VideoFps(Enum):
     """Maximum frames per second."""
 
-    _60 = 60
-    _30 = 30
+    FPS_60 = 60
+    FPS_30 = 30
 
     def __str__(self) -> str:
         return str(self.value)
@@ -304,10 +304,7 @@ def set_audio_format(value: AudioFormat) -> None:
 
 
 def get_audio_bitrate() -> AudioBitrate:
-    return get_setting(
-        SettingKey.AUDIO_BITRATE,
-        AudioBitrate._256KBPS,  # pylint: disable=protected-access
-    )
+    return get_setting(SettingKey.AUDIO_BITRATE, AudioBitrate.KBPS_256)
 
 
 def set_audio_bitrate(value: AudioBitrate) -> None:
@@ -403,10 +400,7 @@ def set_video_format_new(value: VideoCodec) -> None:
 
 
 def get_video_resolution() -> VideoResolution:
-    return get_setting(
-        SettingKey.VIDEO_RESOLUTION_MAX,
-        VideoResolution._1080P,  # pylint: disable=protected-access
-    )
+    return get_setting(SettingKey.VIDEO_RESOLUTION_MAX, VideoResolution.P1080)
 
 
 def set_video_resolution(value: VideoResolution) -> None:
@@ -414,9 +408,7 @@ def set_video_resolution(value: VideoResolution) -> None:
 
 
 def get_video_fps() -> VideoFps:
-    return get_setting(
-        SettingKey.VIDEO_FPS_MAX, VideoFps._60  # pylint: disable=protected-access
-    )
+    return get_setting(SettingKey.VIDEO_FPS_MAX, VideoFps.FPS_60)
 
 
 def set_video_fps(value: VideoFps) -> None:

--- a/src/usdb_syncer/settings.py
+++ b/src/usdb_syncer/settings.py
@@ -27,6 +27,7 @@ class SettingKey(Enum):
     NEWLINE = "downloads/newline"
     AUDIO = "downloads/audio"
     AUDIO_FORMAT = "downloads/audio_format"
+    AUDIO_BITRATE = "downloads/audio_bitrate"
     VIDEO = "downloads/video"
     VIDEO_FORMAT = "downloads/video_format"
     VIDEO_REENCODE = "downloads/video_reencode"
@@ -98,6 +99,22 @@ class AudioFormat(Enum):
     def ytdl_format(self) -> str:
         # prefer best audio-only codec; otherwise take a video codec and extract later
         return f"bestaudio[ext={self.value}]/bestaudio/bestaudio*"
+
+
+class AudioBitrate(Enum):
+    """Audio bitrate."""
+
+    _128KBPS = "128 kbps"
+    _160KBPS = "160 kbps"
+    _192KBPS = "192 kbps"
+    _256KBPS = "256 kbps"
+    _320KBPS = "320 kbps"
+
+    def __str__(self) -> str:
+        return self.value
+
+    def ytdl_format(self) -> str:
+        return self.value.removesuffix(" kbps")
 
 
 class Browser(Enum):
@@ -191,27 +208,47 @@ class VideoCodec(Enum):
 class VideoResolution(Enum):
     """Maximum video resolution."""
 
+    _2160P = "2160p"
+    _1440P = "1440p"
     _1080P = "1080p"
-    _7200P = "720p"
+    _720P = "720p"
+    _480P = "480p"
+    _360P = "360p"
 
     def __str__(self) -> str:
         return self.value
 
     def width(self) -> int:
         match self:
+            case VideoResolution._2160P:
+                return 3840
+            case VideoResolution._1440P:
+                return 2560
             case VideoResolution._1080P:
                 return 1920
-            case VideoResolution._7200P:
+            case VideoResolution._720P:
                 return 1280
+            case VideoResolution._480P:
+                return 854
+            case VideoResolution._360P:
+                return 640
             case _ as unreachable:
                 assert_never(unreachable)
 
     def height(self) -> int:
         match self:
+            case VideoResolution._2160P:
+                return 2160
+            case VideoResolution._1440P:
+                return 1440
             case VideoResolution._1080P:
                 return 1080
-            case VideoResolution._7200P:
+            case VideoResolution._720P:
                 return 720
+            case VideoResolution._480P:
+                return 480
+            case VideoResolution._360P:
+                return 360
             case _ as unreachable:
                 assert_never(unreachable)
 
@@ -264,6 +301,17 @@ def get_audio_format() -> AudioFormat:
 
 def set_audio_format(value: AudioFormat) -> None:
     set_setting(SettingKey.AUDIO_FORMAT, value)
+
+
+def get_audio_bitrate() -> AudioBitrate:
+    return get_setting(
+        SettingKey.AUDIO_BITRATE,
+        AudioBitrate._256KBPS,  # pylint: disable=protected-access
+    )
+
+
+def set_audio_bitrate(value: AudioBitrate) -> None:
+    set_setting(SettingKey.AUDIO_BITRATE, value)
 
 
 def get_newline() -> Newline:


### PR DESCRIPTION
The user can now select the audio bitrate (used if audio is reencoded) and select higher and lower (max) video resolutions.