### PR TITLE
Fix filter width, use enums to identify table columns

### DIFF
--- a/src/usdb_syncer/gui/forms/MainWindow.ui
+++ b/src/usdb_syncer/gui/forms/MainWindow.ui
@@ -98,6 +98,12 @@
     </item>
     <item>
      <widget class="QGroupBox" name="groupBox_4">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Preferred">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <property name="title">
        <string>Filters</string>
       </property>
@@ -122,12 +128,30 @@
          <property name="pixmap">
           <pixmap resource="../resources/resources.qrc">:/icons/artist.png</pixmap>
          </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
         </widget>
        </item>
        <item>
         <widget class="QComboBox" name="comboBox_artist">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>50</width>
+           <height>0</height>
+          </size>
+         </property>
          <property name="editable">
           <bool>false</bool>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
          </property>
          <item>
           <property name="text">
@@ -144,12 +168,30 @@
          <property name="pixmap">
           <pixmap resource="../resources/resources.qrc">:/icons/title.png</pixmap>
          </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
         </widget>
        </item>
        <item>
         <widget class="QComboBox" name="comboBox_title">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Ignored" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>50</width>
+           <height>0</height>
+          </size>
+         </property>
          <property name="editable">
           <bool>false</bool>
+         </property>
+         <property name="sizeAdjustPolicy">
+          <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
          </property>
          <item>
           <property name="text">
@@ -166,10 +208,25 @@
          <property name="pixmap">
           <pixmap resource="../resources/resources.qrc">:/icons/language.png</pixmap>
          </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
         </widget>
        </item>
        <item>
         <widget class="QComboBox" name="comboBox_language">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>50</width>
+           <height>0</height>
+          </size>
+         </property>
          <property name="editable">
           <bool>false</bool>
          </property>
@@ -188,10 +245,25 @@
          <property name="pixmap">
           <pixmap resource="../resources/resources.qrc">:/icons/edition.png</pixmap>
          </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
         </widget>
        </item>
        <item>
         <widget class="QComboBox" name="comboBox_edition">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>0</height>
+          </size>
+         </property>
          <property name="editable">
           <bool>false</bool>
          </property>
@@ -210,10 +282,26 @@
          <property name="pixmap">
           <pixmap resource="../resources/resources.qrc">:/icons/golden_notes.png</pixmap>
          </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="comboBox_golden_notes"/>
+        <widget class="QComboBox" name="comboBox_golden_notes">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QLabel" name="label_15">
@@ -223,10 +311,26 @@
          <property name="pixmap">
           <pixmap resource="../resources/resources.qrc">:/icons/rating.png</pixmap>
          </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="comboBox_rating"/>
+        <widget class="QComboBox" name="comboBox_rating">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>50</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
        </item>
        <item>
         <widget class="QLabel" name="label_16">
@@ -236,13 +340,26 @@
          <property name="pixmap">
           <pixmap resource="../resources/resources.qrc">:/icons/views.png</pixmap>
          </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="comboBox_views"/>
-       </item>
-       <item>
-        <widget class="QComboBox" name="comboBox_sync_status"/>
+        <widget class="QComboBox" name="comboBox_views">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>30</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/usdb_syncer/gui/song_table/column.py
+++ b/src/usdb_syncer/gui/song_table/column.py
@@ -1,6 +1,6 @@
 """Table model for song data."""
 
-from enum import Enum
+from enum import Enum, IntEnum
 from functools import cache
 
 from PySide6.QtCore import QModelIndex, QPersistentModelIndex
@@ -17,7 +17,7 @@ class CustomRole(int, Enum):
     ALL_DATA = 100
 
 
-class Column(Enum):
+class Column(IntEnum):
     """Table columns."""
 
     SONG_ID = 0

--- a/src/usdb_syncer/gui/song_table/song_table.py
+++ b/src/usdb_syncer/gui/song_table/song_table.py
@@ -10,6 +10,7 @@ from PySide6.QtCore import QItemSelection, QItemSelectionModel, QModelIndex, QOb
 from PySide6.QtWidgets import QAbstractItemView, QHeaderView, QTableView
 
 from usdb_syncer import SongId
+from usdb_syncer.gui.song_table.column import Column
 from usdb_syncer.gui.song_table.sort_filter_proxy_model import SortFilterProxyModel
 from usdb_syncer.gui.song_table.table_model import CustomRole, TableModel
 from usdb_syncer.logger import get_logger
@@ -40,28 +41,32 @@ class SongTable:
     def _setup_table_header(self) -> None:
         header = self._view.horizontalHeader()
         header.setSectionResizeMode(QHeaderView.ResizeMode.ResizeToContents)
-        header.setSectionResizeMode(0, QHeaderView.ResizeMode.Fixed)
-        header.resizeSection(0, 84)
-        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Interactive)
-        header.setSectionResizeMode(2, QHeaderView.ResizeMode.Interactive)
-        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Interactive)
-        header.setSectionResizeMode(4, QHeaderView.ResizeMode.Interactive)
-        header.setSectionResizeMode(5, QHeaderView.ResizeMode.Fixed)
-        header.resizeSection(5, header.sectionSize(5))
-        header.setSectionResizeMode(6, QHeaderView.ResizeMode.Fixed)
-        header.resizeSection(6, header.sectionSize(6))
-        header.setSectionResizeMode(7, QHeaderView.ResizeMode.Fixed)
-        header.resizeSection(7, header.sectionSize(7))
-        header.setSectionResizeMode(8, QHeaderView.ResizeMode.Fixed)
-        header.resizeSection(8, 24)
-        header.setSectionResizeMode(9, QHeaderView.ResizeMode.Fixed)
-        header.resizeSection(9, 24)
-        header.setSectionResizeMode(10, QHeaderView.ResizeMode.Fixed)
-        header.resizeSection(10, 24)
-        header.setSectionResizeMode(11, QHeaderView.ResizeMode.Fixed)
-        header.resizeSection(11, 24)
-        header.setSectionResizeMode(12, QHeaderView.ResizeMode.Fixed)
-        header.resizeSection(12, 24)
+        header.setSectionResizeMode(Column.SONG_ID, QHeaderView.ResizeMode.Fixed)
+
+        font_metrics = header.fontMetrics()
+        header.resizeSection(Column.SONG_ID, font_metrics.horizontalAdvance("1234567"))
+        header.setSectionResizeMode(Column.ARTIST, QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(Column.TITLE, QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(Column.LANGUAGE, QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(Column.EDITION, QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(Column.GOLDEN_NOTES, QHeaderView.ResizeMode.Fixed)
+        header.resizeSection(
+            Column.GOLDEN_NOTES, header.sectionSize(Column.GOLDEN_NOTES)
+        )
+        header.setSectionResizeMode(Column.RATING, QHeaderView.ResizeMode.Fixed)
+        header.resizeSection(Column.RATING, header.sectionSize(Column.RATING))
+        header.setSectionResizeMode(Column.VIEWS, QHeaderView.ResizeMode.Fixed)
+        header.resizeSection(Column.VIEWS, header.sectionSize(Column.VIEWS))
+        header.setSectionResizeMode(Column.TXT, QHeaderView.ResizeMode.Fixed)
+        header.resizeSection(Column.TXT, 24)
+        header.setSectionResizeMode(Column.AUDIO, QHeaderView.ResizeMode.Fixed)
+        header.resizeSection(Column.AUDIO, 24)
+        header.setSectionResizeMode(Column.VIDEO, QHeaderView.ResizeMode.Fixed)
+        header.resizeSection(Column.VIDEO, 24)
+        header.setSectionResizeMode(Column.COVER, QHeaderView.ResizeMode.Fixed)
+        header.resizeSection(Column.COVER, 24)
+        header.setSectionResizeMode(Column.BACKGROUND, QHeaderView.ResizeMode.Fixed)
+        header.resizeSection(Column.BACKGROUND, 24)
 
     ### selection model
 


### PR DESCRIPTION
This PR currently contains two changes, though both are just suggestions so please let me know if you think they make sense or should be changed or removed.

The first change is setting a minimum width on the filter combo boxes. This does not affect how the combo boxes are displayed on larger screens but on smaller screens this allows them to shrink and this in turn allows the entire window to fit smaller screens. This problem is outlined in #69.

The second change introduces the use of IntEnums for the table columns instead of referencing them using their index. Currently the ID column width is dynamically derived from the font width.