### PR TITLE
Remove trailing dots (and resulting spaces) in filenames.

### DIFF
--- a/src/usdb_syncer/utils.py
+++ b/src/usdb_syncer/utils.py
@@ -67,6 +67,8 @@ def sanitize_filename(fname: str) -> str:
     for old, new in FILENAME_REPLACEMENTS:
         for char in old:
             fname = fname.replace(char, new)
+    if fname.endswith("."):
+        fname = fname.rstrip(" .")  # Windows does not like trailing periods
     return fname
 
 


### PR DESCRIPTION
Technically only needed for Windows, but it is always done in order to support OS-independent song collections.