### PR TITLE
fixes broken loudness normalization for input_lra < 1, by using newest ffmpeg_normalize and new option

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     pyshorteners
     filetype
     browser_cookie3
-    ffmpeg-normalize
+    ffmpeg-normalize>=1.27
 
 [options.packages.find]
 where = src

--- a/src/usdb_syncer/resource_dl.py
+++ b/src/usdb_syncer/resource_dl.py
@@ -89,7 +89,8 @@ def _normalize(options: AudioOptions, path_stem: Path, filename: str) -> None:
         normalization_type="ebu",  # default: "ebu"
         target_level=-23,  # default: -23
         print_stats=True,  # set to False?
-        keep_loudness_range_target=True,  # needed for linear normalization
+        keep_lra_above_loudness_range_target=True,  # needed for linear normalization
+        loudness_range_target=7,  # default: 7.0
         true_peak=-2,  # default: -2
         dynamic=False,  # default: False
         audio_codec=options.format.ffmpeg_encoder(),


### PR DESCRIPTION
Songs having `input_LRA < 1.0` currently cannot be normalized and break download process with error message like

```
Value 0.800000 for parameter 'lra' out of range [1 - 50]
Error applying option 'lra' to filter
```

Due to using `keep_loudness_range_target = True` in `ffmpeg_normalize`, the 1st pass measure of `input_lra` is directly written to the 2nd pass `LRA`-value. Unfortunately `ffmpeg` only allows `LRA` to be within `[1, 50]`, hence this fails if `input_lra` is lower than 1.

Recently `ffmpeg_normalize` added a new flag `keep_lra_above_loudness_range_target` were all `input_lra <= 7` are set to `7` and all `input_lra > 7` are set to `input_lra` (setting less `LRA` than `input_lra` would automatically result in `Dynamic` loudness normalization).

This PR uses the new `ffmpeg_normalize` version `1.27.0` together with the new flag and explicitly sets `loudness_range_target` to the default `7.0` (which is what we want to set due to EBU-Standard)

Songs I tested with:

| input_lra | USDB ID | Song                                           |
|:---------:|:-------:|:----------------------------------------------:|
|   0.80    |  26658  | Gary Moore - Shapes Of Things                  |
|   0.70    |  03468  | Disney’s Darkwing Duck - Theme                 |
|  16.10    |  10581  | Disney’s The Lion King - Circle Of Life [DUET] |

The first 2 songs previously led to an error. The 3rd song has LRA > 7 in order to check if the 2nd pass sets `LRA=16.10` as expected