### PR TITLE
fixes #137 by adding missing dependencies to linux build workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -47,6 +47,10 @@ jobs:
         run: generate_pyside_files
       - name: Scrape USDB song list to ship with the bundle
         run: generate_song_list_json -t 'data/song_list.json' -u '${{ secrets.USDB_USER }}' -p '${{ secrets.USDB_PASSWORD }}'
+      - name: add dependencies for xcb support
+        if: matrix.TARGET == 'Linux'
+        run: |
+          sudo apt install libxcb-cursor0
       - name: Build with pyinstaller for ${{matrix.os}}
         run: pyinstaller -n 'USDB_Syncer-${{github.ref_name}}-${{matrix.TARGET}}' ${{matrix.PYINSTALLER_ARGS}} src/usdb_syncer/main.py
       - name: Create DMG

--- a/README.md
+++ b/README.md
@@ -6,16 +6,54 @@
 [![Release](https://github.com/bohning/usdb_syncer/actions/workflows/release.yaml/badge.svg)](https://github.com/bohning/usdb_syncer/actions/workflows/release.yaml)
 [![tox](https://github.com/bohning/usdb_syncer/actions/workflows/tox.yaml/badge.svg)](https://github.com/bohning/usdb_syncer/actions/workflows/tox.yaml)
 
-## Install (Linux)
+## Linux Distributions
 
-requires extra packages on Linux
+Linux Build are generated on `Ubuntu:latest`, should run on `Ubuntu >=23.04`
 
-``` bash
-apt update
-apt install libdbus-1-3
-```
+known requirements:
+
+- package `glibc >= 2.35`
+
+  Therefore the following table (based on https://pkgs.org/search/?q=glibc, 8.7.2023) summarizes different Linux Distributions for having greater or equal version of `glibc`. For (likely) supported distributions the minimum OS Version is given that has a required glibc version. For (likely) unsupported distributions the recent highest Versions (if known) of Linux Distributions with its highest glibc version is given:
+
+  |                    | OS                  | OS Version       | glibc     |
+  |:------------------:|:-------------------:|:----------------:|:---------:|
+  | :x:                | AlmaLinux           | 9                | 2.34 |
+  | :x:                | ALT Linux           | P10              | 2.32 |
+  | :x:                | Amazon Linux        | 2                | 2.26 |
+  | :white_check_mark: | Arch Linux          |                  | 2.37 |
+  | :x:                | CentOS              | 9                | 2.34 |
+  | :x:                | Enterprise Linux    | 7                | 2.24 |
+  | :white_check_mark: | Debian              | 12 "Bookworm"    | 2.36 |
+  | :white_check_mark: | Fedora              | 38               | 2.37 |
+  | :white_check_mark: | KaOS                |                  | 2.36 |
+  | :white_check_mark: | Mageia              | Cauldron         | 2.36 |
+  | :white_check_mark: | OpenMandriva        | Rolling & Cooker | 2.37 |
+  | :white_check_mark: | openSUSE Tumbleweed |                  | 2.37 |
+  | :x:                | Oracle Linux        | 9                | 2.34 |
+  | :white_check_mark: | PCLinuxOS           |                  | 2.36 |
+  | :x:                | Rocky Linux         | 9                | 2.34 |
+  | :white_check_mark: | Slackware           |                  | 2.37 |
+  | :white_check_mark: | Solus               |                  | 2.36 |
+  | :white_check_mark: | Ubuntu              | 23.04            | 2.35 |
+  | :white_check_mark: | Void Linux          |                  | 2.36 |
+
+  :x: pretty sure not working
+
+  :white_check_mark: should work
+
+confirmed support:
+
+- Ubuntu 23.04
 
 ### Troubleshooting
+
+- may require extra packages on Linux
+
+  ``` bash
+  apt update
+  apt install libdbus-1-3
+  ```
 
 - The `keyring` package auto-detects an appropriate installed keyring backend (see [PyPI - keyring](https://pypi.org/project/keyring/)). Thus may require following additional package if no backend can be detected, see #136
 


### PR DESCRIPTION
Adding installation of `libxcb-cursor0` created a linux executable that runs without this error on Ubuntu 23.04.

- [`0.1.10020`](https://github.com/mjhalwa/usdb_syncer/releases/tag/0.1.10020)

For now started with this as Pull-Request to fix this issue. I am waiting for other users to report, if this works for them or if any of the following solutions works instead.

From searching the web I found several other packages that might be required (I know there are some dublicate packages):

- [`0.1.10021`](https://github.com/mjhalwa/usdb_syncer/releases/tag/0.1.10021)

  ``` bash
  sudo apt install libxcb-cursor0
  sudo apt install libxcb-xinerama0
  ```

- [`0.1.10022`](https://github.com/mjhalwa/usdb_syncer/releases/tag/0.1.10022)

  ``` bash
  sudo apt install libxcb-cursor0
  sudo apt install libxcb-xinerama0
  sudo apt install -y \
            libfontconfig1-dev libfreetype6-dev \
            libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev \
            libxi-dev libxrender-dev \
            libxkbcommon-dev libxkbcommon-x11-dev libatspi2.0-dev \
            libopengl0 '^libxcb.*-dev'
  ```

- [`0.1.10023`](https://github.com/mjhalwa/usdb_syncer/releases/tag/0.1.10023)

  ``` bash
  sudo apt install libxcb-cursor0
  sudo apt install libxcb-xinerama0
  sudo apt install -y \
            libfontconfig1-dev libfreetype6-dev \
            libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev \
            libxi-dev libxrender-dev \
            libxkbcommon-dev libxkbcommon-x11-dev libatspi2.0-dev \
            libopengl0 '^libxcb.*-dev'
  sudo apt install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
  ```

- [`0.1.10024`](https://github.com/mjhalwa/usdb_syncer/releases/tag/0.1.10024)

  ``` bash
  sudo apt install libxcb-cursor0
  sudo apt install libxcb-xinerama0
  sudo apt install -y \
            libfontconfig1-dev libfreetype6-dev \
            libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev \
            libxi-dev libxrender-dev \
            libxkbcommon-dev libxkbcommon-x11-dev libatspi2.0-dev \
            libopengl0 '^libxcb.*-dev'
  sudo apt install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
    sudo apt install libwebp-dev libxau-dev
  ```

  Note: tried to fix the warnings of the build process with `libwebp-dev` and `libxau-dev`, but still has same warnings

- [`0.1.10025`](https://github.com/mjhalwa/usdb_syncer/releases/tag/0.1.10025)

  ``` bash
  sudo apt update -y && sudo apt upgrade -y
  sudo apt install libxcb-cursor0
  sudo apt install libxcb-xinerama0
  sudo apt install -y \
            libfontconfig1-dev libfreetype6-dev \
            libx11-dev libx11-xcb-dev libxext-dev libxfixes-dev \
            libxi-dev libxrender-dev \
            libxkbcommon-dev libxkbcommon-x11-dev libatspi2.0-dev \
            libopengl0 '^libxcb.*-dev'
  sudo apt install '^libxcb.*-dev' libx11-xcb-dev libglu1-mesa-dev libxrender-dev libxi-dev libxkbcommon-dev libxkbcommon-x11-dev
    sudo apt install libwebp-dev libxau-dev
  ```

**[EDIT]:** To clarify, the linked Releases include the fix of Issue #136 as the combination of both actually runs. Anyways ths PR contians **just** the fix for #137. Both PRs need to be accepted in order for the next release to work.