### PR TITLE
change import of pyshorteners to directly import submodules to fix #144

### DIFF
--- a/src/usdb_syncer/gui/meta_tags_dialog.py
+++ b/src/usdb_syncer/gui/meta_tags_dialog.py
@@ -2,13 +2,13 @@
 
 from typing import Callable, Literal
 
-from pyshorteners.shorteners import tinyurl
 from pyshorteners.exceptions import (
     BadAPIResponseException,
     BadURLException,
     ExpandingErrorException,
     ShorteningErrorException,
 )
+from pyshorteners.shorteners import tinyurl
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import QDialog, QWidget
 

--- a/src/usdb_syncer/gui/meta_tags_dialog.py
+++ b/src/usdb_syncer/gui/meta_tags_dialog.py
@@ -8,6 +8,16 @@ from pyshorteners.exceptions import (
     ExpandingErrorException,
     ShorteningErrorException,
 )
+
+# Note: prevent import error in production by importing shorteners directoy instead of
+#
+#         from pyshorteners import Shortener
+#
+#       which loads all shorteners from all python modules from its subfolder. Creating
+#       a build with pyinstaller seems to leave the submodules out, because submodules
+#       can then not be imported in a production build with error
+#
+#         ModuleNotFoundError: No module named 'pyshorteners.shorteners'
 from pyshorteners.shorteners import tinyurl
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import QDialog, QWidget

--- a/src/usdb_syncer/gui/meta_tags_dialog.py
+++ b/src/usdb_syncer/gui/meta_tags_dialog.py
@@ -8,16 +8,6 @@ from pyshorteners.exceptions import (
     ExpandingErrorException,
     ShorteningErrorException,
 )
-
-# Note: prevent import error in production by importing shorteners directoy instead of
-#
-#         from pyshorteners import Shortener
-#
-#       which loads all shorteners from all python modules from its subfolder. Creating
-#       a build with pyinstaller seems to leave the submodules out, because submodules
-#       can then not be imported in a production build with error
-#
-#         ModuleNotFoundError: No module named 'pyshorteners.shorteners'
 from pyshorteners.shorteners import tinyurl
 from PySide6.QtGui import QGuiApplication
 from PySide6.QtWidgets import QDialog, QWidget

--- a/src/usdb_syncer/gui/meta_tags_dialog.py
+++ b/src/usdb_syncer/gui/meta_tags_dialog.py
@@ -2,7 +2,7 @@
 
 from typing import Callable, Literal
 
-from pyshorteners import Shortener
+from pyshorteners.shorteners import tinyurl
 from pyshorteners.exceptions import (
     BadAPIResponseException,
     BadURLException,
@@ -213,7 +213,7 @@ def _urls_and_setters(tags: MetaTags) -> list[tuple[str, Callable[[str], None]]]
 
 def _try_shorten_url(url: str) -> str:
     try:
-        short = Shortener().tinyurl.short(url).removeprefix("https://")
+        short = tinyurl.Shortener().short(url).removeprefix("https://")
     except (
         BadAPIResponseException,
         BadURLException,


### PR DESCRIPTION
fixes #144 

The following code

```
from pyshorteners import Shortener
# ...
short = Shortener().tinyurl.short(url).removeprefix("https://")
```

seems to be problematic in production, as `Shortener` initializes by reading all shortener python-modules from a subdirectory. This seems to work in development, but pyinstaller probably leaves out the subdirectory. Only if directly importing the submodule, the issue vanishes in production too

```
from pyshorteners import shorteners
# ...
short = shorteners.Shortener().tinyurl.short(url).removeprefix("https://")
```

`meta_tags_dialog.py` is the only python module using `pyshorteners` and we only use `tinyurl` shortener.