### PR TITLE
avoid parsing meta-tags on updating local file list

### DIFF
--- a/src/usdb_syncer/song_list_fetcher.py
+++ b/src/usdb_syncer/song_list_fetcher.py
@@ -74,7 +74,9 @@ def find_local_files() -> dict[SongId, LocalFiles]:
     for path in settings.get_song_dir().glob("**/*.usdb"):
         if meta := SyncMeta.try_from_file(path):
             local_files[meta.song_id] = files = LocalFiles(usdb_path=path)
-            if txt := _get_song_txt(meta, path.parent):
+            if txt := _get_song_txt(
+                meta=meta, folder=path.parent, parse_meta_tags=False
+            ):
                 files.txt = True
                 files.audio = _file_exists(path.parent, txt.headers.mp3)
                 files.video = _file_exists(path.parent, txt.headers.video)
@@ -83,13 +85,15 @@ def find_local_files() -> dict[SongId, LocalFiles]:
     return local_files
 
 
-def _get_song_txt(meta: SyncMeta, folder: Path) -> SongTxt | None:
+def _get_song_txt(
+    meta: SyncMeta, folder: Path, parse_meta_tags: bool = True
+) -> SongTxt | None:
     if not meta.txt:
         return None
     txt_path = folder.joinpath(meta.txt.fname)
     logger = get_logger(__file__, meta.song_id)
     if txt_path.exists() and (contents := try_read_unknown_encoding(txt_path)):
-        return SongTxt.try_parse(contents, logger)
+        return SongTxt.try_parse(contents, logger, parse_meta_tags)
     return None
 
 

--- a/src/usdb_syncer/song_txt/__init__.py
+++ b/src/usdb_syncer/song_txt/__init__.py
@@ -44,19 +44,25 @@ class SongTxt:
         ]
 
     @classmethod
-    def parse(cls, value: str, logger: Log) -> SongTxt:
+    def parse(cls, value: str, logger: Log, parse_meta_tags: bool = True) -> SongTxt:
         lines = [line for line in value.splitlines() if line]
         headers = Headers.parse(lines, logger)
-        meta_tags = MetaTags.parse(headers.video or "", logger)
+        meta_tags = meta_tags = (
+            MetaTags.parse(headers.video or "", logger)
+            if parse_meta_tags
+            else MetaTags()
+        )
         notes = Tracks.parse(lines, logger)
         if lines:
             logger.warning(f"trailing text in song txt: '{lines}'")
         return cls(headers=headers, meta_tags=meta_tags, notes=notes, logger=logger)
 
     @classmethod
-    def try_parse(cls, value: str, logger: Log) -> SongTxt | None:
+    def try_parse(
+        cls, value: str, logger: Log, parse_meta_tags: bool = True
+    ) -> SongTxt | None:
         try:
-            return cls.parse(value, logger)
+            return cls.parse(value, logger, parse_meta_tags)
         except NotesParseError:
             return None
 


### PR DESCRIPTION
As local files should not contain any meta-tags any more I propose fixing #169 by introducing a bool to skip parsing meta tags when loading local file list to (prior)

```
def find_local_files() -> dict[SongId, LocalFiles]:
    local_files: dict[SongId, LocalFiles] = {}
    for path in settings.get_song_dir().glob("**/*.usdb"):
        if meta := SyncMeta.try_from_file(path):
            local_files[meta.song_id] = files = LocalFiles(usdb_path=path)
            if txt := _get_song_txt(meta, path.parent):
                files.txt = True
                files.audio = _file_exists(path.parent, txt.headers.mp3)
                files.video = _file_exists(path.parent, txt.headers.video)
                files.cover = _file_exists(path.parent, txt.headers.cover)
                files.background = _file_exists(path.parent, txt.headers.background)
    return local_files
```

because the parsed meta-tags of `txt` are not used anywhere here.

But I am open for other suggestions ;)