### PR TITLE
Project description so people know what this project is about

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,11 @@
 [![Release](https://github.com/bohning/usdb_syncer/actions/workflows/release.yaml/badge.svg)](https://github.com/bohning/usdb_syncer/actions/workflows/release.yaml)
 [![tox](https://github.com/bohning/usdb_syncer/actions/workflows/tox.yaml/badge.svg)](https://github.com/bohning/usdb_syncer/actions/workflows/tox.yaml)
 
+**USDB Syncer** is an app to download and synchronize UltraStar songs hosted on [USDB](https://usdb.animux.de).
+The project [extensively uses the `#VIDEO` tag](https://github.com/bohning/usdb_syncer/wiki/Meta-Tags#format) to automaticly retrieve the resources (audio, video, images, etc...) to make the UltraStar song complete.
+Once a song is downloaded it can be synchronized (new notes, audio, video, images...) by redownloading the song. If a resource didn't change it's skipped.
+The project can be used from the commandline, but also has a GUI available.
+
 ## Linux Distributions
 
 Linux Build are generated on `Ubuntu:latest`, should run on `Ubuntu >=23.04`

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 **USDB Syncer** is an app to download and synchronize UltraStar songs hosted on [USDB](https://usdb.animux.de).
 The project [extensively uses the `#VIDEO` tag](https://github.com/bohning/usdb_syncer/wiki/Meta-Tags#format) to automaticly retrieve the resources (audio, video, images, etc...) to make the UltraStar song complete.
 Once a song is downloaded it can be synchronized (new notes, audio, video, images...) by redownloading the song. If a resource didn't change it's skipped.
-The project can be used from the commandline, but also has a GUI available.
 
 ## Linux Distributions
 


### PR DESCRIPTION
### Changes

Updates the readme to include a small description of the project.
The first line is copied over from https://github.com/bohning/usdb_syncer/blob/main/src/usdb_syncer/main.py#L31 and extended so the hosting site is included.

### Issues

Fixes #179

### Motivation

A project description is nice to have so people know what the project is about.

### Extra info

Please change the text accordingly if it doesn't explain all of USDB Syncer