### PR TITLE
Use a connectionpool with a limit of 100 connections to usdb.

### DIFF
--- a/src/usdb_syncer/usdb_scraper.py
+++ b/src/usdb_syncer/usdb_scraper.py
@@ -64,6 +64,9 @@ def new_session_with_cookies(browser: settings.Browser) -> Session:
     if cookies := browser.cookies():
         for cookie in cookies:
             session.cookies.set_cookie(cookie)
+    adapter = requests.adapters.HTTPAdapter(pool_connections=100, pool_maxsize=100)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
     return session
 
 


### PR DESCRIPTION
The default http-pool is 10 connections. To increase this we must create an adapter and then mount that to the session.

Current value is 100 concurrent connections.

This improves the calls done with the session. So not video's downloading through yt-dlp.
Haven't found a way to parallize that more