### PR TITLE
Add an option to choose the preferred apostrophe

### DIFF
--- a/src/usdb_syncer/download_options.py
+++ b/src/usdb_syncer/download_options.py
@@ -7,6 +7,13 @@ from usdb_syncer import settings
 
 
 @dataclass(frozen=True)
+class MiscOptions:
+    """Miscellaneous settings that must always be present."""
+
+    apostrophe: settings.Apostrophe
+
+
+@dataclass(frozen=True)
 class TxtOptions:
     """Settings regarding the song txt file to be downloaded."""
 
@@ -67,6 +74,7 @@ class Options:
     """Settings for downloading songs."""
 
     song_dir: Path
+    misc_options: MiscOptions
     txt_options: TxtOptions | None
     audio_options: AudioOptions | None
     browser: settings.Browser
@@ -78,6 +86,7 @@ class Options:
 def download_options() -> Options:
     return Options(
         song_dir=settings.get_song_dir(),
+        misc_options=_misc_options(),
         txt_options=_txt_options(),
         audio_options=_audio_options(),
         browser=settings.get_browser(),
@@ -85,6 +94,10 @@ def download_options() -> Options:
         cover=_cover_options(),
         background_options=_background_options(),
     )
+
+
+def _misc_options() -> MiscOptions:
+    return MiscOptions(settings.get_apostrophe())
 
 
 def _txt_options() -> TxtOptions | None:

--- a/src/usdb_syncer/gui/forms/SettingsDialog.ui
+++ b/src/usdb_syncer/gui/forms/SettingsDialog.ui
@@ -106,6 +106,26 @@
           </property>
          </widget>
         </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_song_file_apostrophes">
+          <property name="text">
+           <string>Apostrophes:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="comboBox_apostrophes">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+            <horstretch>1</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Choose the type of apostrophe you prefer. Both types should be supported by USDX and variants, but in rare cases the typograhper's apostrophe may cause issues.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>

--- a/src/usdb_syncer/gui/settings_dialog.py
+++ b/src/usdb_syncer/gui/settings_dialog.py
@@ -24,6 +24,8 @@ class SettingsDialog(Ui_Dialog, QDialog):
             self.comboBox_encoding.addItem(str(encoding), encoding)
         for newline in settings.Newline:
             self.comboBox_line_endings.addItem(str(newline), newline)
+        for apostrophe in settings.Apostrophe:
+            self.comboBox_apostrophes.addItem(str(apostrophe), apostrophe)
         for container in settings.AudioFormat:
             self.comboBox_audio_format.addItem(str(container), container)
         for bitrate in settings.AudioBitrate:
@@ -51,6 +53,9 @@ class SettingsDialog(Ui_Dialog, QDialog):
         )
         self.comboBox_line_endings.setCurrentIndex(
             self.comboBox_line_endings.findData(settings.get_newline())
+        )
+        self.comboBox_apostrophes.setCurrentIndex(
+            self.comboBox_apostrophes.findData(settings.get_apostrophe())
         )
         self.groupBox_audio.setChecked(settings.get_audio())
         self.comboBox_audio_format.setCurrentIndex(
@@ -91,6 +96,7 @@ class SettingsDialog(Ui_Dialog, QDialog):
         settings.set_txt(self.groupBox_songfile.isChecked())
         settings.set_encoding(self.comboBox_encoding.currentData())
         settings.set_newline(self.comboBox_line_endings.currentData())
+        settings.set_apostrophe(self.comboBox_apostrophes.currentData())
         settings.set_audio(self.groupBox_audio.isChecked())
         settings.set_audio_format(self.comboBox_audio_format.currentData())
         settings.set_audio_bitrate(self.comboBox_audio_bitrate.currentData())

--- a/src/usdb_syncer/settings.py
+++ b/src/usdb_syncer/settings.py
@@ -58,6 +58,7 @@ class SettingKey(Enum):
     TXT = "downloads/txt"
     ENCODING = "downloads/encoding"
     NEWLINE = "downloads/newline"
+    APOSTROPHE = "downloads/apostrophe"
     AUDIO = "downloads/audio"
     AUDIO_FORMAT = "downloads/audio_format"
     AUDIO_BITRATE = "downloads/audio_bitrate"
@@ -119,6 +120,22 @@ class Newline(Enum):
         if os.linesep == Newline.CRLF.value:
             return Newline.CRLF
         return Newline.LF
+
+
+class Apostrophe(Enum):
+    """Apostrophe normalization for song txts."""
+
+    TYPOGRAPHER = "’"
+    UPRIGHT = "'"
+
+    def __str__(self) -> str:
+        match self:
+            case Apostrophe.TYPOGRAPHER:
+                return "Typographer's Apostrophe (’)"
+            case Apostrophe.UPRIGHT:
+                return "Upright Apostrophe (')"
+            case _ as unreachable:
+                assert_never(unreachable)
 
 
 class AudioFormat(Enum):
@@ -470,6 +487,14 @@ def get_encoding() -> Encoding:
 
 def set_encoding(value: Encoding) -> None:
     set_setting(SettingKey.ENCODING, value)
+
+
+def get_apostrophe() -> Apostrophe:
+    return get_setting(SettingKey.APOSTROPHE, Apostrophe.TYPOGRAPHER)
+
+
+def set_apostrophe(value: Apostrophe) -> None:
+    set_setting(SettingKey.APOSTROPHE, value)
 
 
 def get_txt() -> bool:

--- a/src/usdb_syncer/song_loader.py
+++ b/src/usdb_syncer/song_loader.py
@@ -123,7 +123,7 @@ class Context:
     ) -> Context:
         txt_str = usdb_scraper.get_notes(details.song_id, logger)
         txt = SongTxt.parse(txt_str, logger)
-        txt.sanitize()
+        txt.sanitize(options.misc_options.apostrophe.value)
         txt.headers.creator = txt.headers.creator or details.uploader or None
         paths = Locations.new(
             details.song_id, options.song_dir, info.meta_path, txt.headers

--- a/src/usdb_syncer/song_txt/__init__.py
+++ b/src/usdb_syncer/song_txt/__init__.py
@@ -80,12 +80,12 @@ class SongTxt:
         ) as file:
             file.write(str(self))
 
-    def sanitize(self) -> None:
+    def sanitize(self, apostrophe: str) -> None:
         """Sanitize USDB issues and prepare for local usage."""
         self.headers.reset_file_location_headers()
-        self.fix()
+        self.fix(apostrophe)
 
-    def fix(self) -> None:
+    def fix(self, apostrophe: str) -> None:
         # non-optional fixes
         self.fix_relative_songs()
         self.notes.maybe_split_duet_notes()
@@ -95,8 +95,8 @@ class SongTxt:
         self.notes.fix_overlapping_and_touching_notes(self.logger)
         self.notes.fix_line_breaks(self.logger)
         self.notes.fix_pitch_values(self.logger)
-        self.notes.fix_apostrophes_and_quotation_marks(self.logger)
-        self.headers.fix_apostrophes(self.logger)
+        self.notes.fix_apostrophes_and_quotation_marks(apostrophe, self.logger)
+        self.headers.fix_apostrophes(apostrophe, self.logger)
         self.notes.fix_spaces(self.logger)
         self.notes.fix_all_caps(self.logger)
         self.notes.fix_first_words_capitalization(self.logger)

--- a/src/usdb_syncer/song_txt/headers.py
+++ b/src/usdb_syncer/song_txt/headers.py
@@ -147,11 +147,13 @@ class Headers:
     def artist_title_str(self) -> str:
         return f"{self.artist} - {self.title}"
 
-    def fix_apostrophes(self, logger: Log) -> None:
+    def fix_apostrophes(self, apostrophe: str, logger: Log) -> None:
         apostrophes_and_quotation_marks_fixed = False
         for key in ("artist", "title", "language", "genre", "p1", "p2", "album"):
             if value := getattr(self, key):
-                corrected_value = replace_false_apostrophes_and_quotation_marks(value)
+                corrected_value = replace_false_apostrophes_and_quotation_marks(
+                    value, apostrophe
+                )
                 if value != corrected_value:
                     setattr(self, key, corrected_value)
                     apostrophes_and_quotation_marks_fixed = True

--- a/src/usdb_syncer/song_txt/tracks.py
+++ b/src/usdb_syncer/song_txt/tracks.py
@@ -303,11 +303,13 @@ class Tracks:
                 f"FIX: pitch values normalized (shifted by {octave_shift} octaves)."
             )
 
-    def fix_apostrophes_and_quotation_marks(self, logger: Log) -> None:
+    def fix_apostrophes_and_quotation_marks(self, apostrophe: str, logger: Log) -> None:
         note_text_fixed = 0
         for note in self.all_notes():
             note_text_old = note.text
-            note.text = replace_false_apostrophes_and_quotation_marks(note_text_old)
+            note.text = replace_false_apostrophes_and_quotation_marks(
+                note_text_old, apostrophe
+            )
             if note_text_old != note.text:
                 note_text_fixed += 1
         if note_text_fixed > 0:
@@ -420,16 +422,17 @@ def fix_line_breaks(lines: list[Line]) -> None:
         last_line = line
 
 
-def replace_false_apostrophes_and_quotation_marks(value: str) -> str:
+def replace_false_apostrophes_and_quotation_marks(value: str, apostrophe: str) -> str:
     # two single upright quotation marks ('') by double upright quotation marks (")
     # grave accent (`), acute accent (´), prime symbol (′) and upright apostrophe (')
-    # by typographer’s apostrophe (’)
+    # by user's choice (typographer’s apostrophe (’) or upright apostrophe ('))
     return (
         value.replace("''", '"')
-        .replace("`", "’")
-        .replace("´", "’")
-        .replace("′", "’")
-        .replace("'", "’")
+        .replace("`", apostrophe)
+        .replace("´", apostrophe)
+        .replace("′", apostrophe)
+        .replace("’", apostrophe)
+        .replace("'", apostrophe)
     )
 
 

--- a/tests/resources/txt/fixes/apostrophes_typographer.txt
+++ b/tests/resources/txt/fixes/apostrophes_typographer.txt
@@ -1,0 +1,15 @@
+#ARTIST:Mi’st’er ’B’ean
+#TITLE:S’too’early
+#MP3:Mi’st’er ’B’ean - S’too’early.mp3
+#LANGUAGE:g’rman
+#BPM:244
+#GAP:2910
+F 14 5 27 ba’da’m
+F 20 61 17 mil’jen
+- 81
+: 82 1 5 ’n halb’s
+: 84 3 12 E’
+: 88 1 12 compe’
+: 90 1 10  ’SCON
+: 92 3 8 to’ta,
+E

--- a/tests/resources/txt/fixes/apostrophes_upright.txt
+++ b/tests/resources/txt/fixes/apostrophes_upright.txt
@@ -1,0 +1,15 @@
+#ARTIST:Mi'st'er 'B'ean
+#TITLE:S'too'early
+#MP3:Mi'st'er 'B'ean - S'too'early.mp3
+#LANGUAGE:g'rman
+#BPM:244
+#GAP:2910
+F 14 5 27 ba'da'm
+F 20 61 17 mil'jen
+- 81
+: 82 1 5 'n halb's
+: 84 3 12 E'
+: 88 1 12 compe'
+: 90 1 10  'SCON
+: 92 3 8 to'ta,
+E

--- a/tests/unit/song_txt/test_notes_parser.py
+++ b/tests/unit/song_txt/test_notes_parser.py
@@ -37,7 +37,21 @@ def test_notes_parser_fixes(resource_dir: str) -> None:
         with open(path.replace("_in.txt", "_out.txt"), encoding="utf-8") as file:
             out = file.read()
         txt = SongTxt.parse(contents, _logger)
-        txt.fix()
+        txt.fix("’")
+        assert str(txt) == out, f"failed test for '{path}'"
+
+
+def test_notes_parser_fixes_upright_apostrophes(resource_dir: str) -> None:
+    folder = os.path.join(resource_dir, "txt", "fixes")
+    for path in glob(f"{folder}/*_typograhper.txt"):
+        with open(path, encoding="utf-8") as file:
+            contents = file.read()
+        with open(
+            path.replace("_typograhper.txt", "_upright.txt"), encoding="utf-8"
+        ) as file:
+            out = file.read()
+        txt = SongTxt.parse(contents, _logger)
+        txt.fix("'")
         assert str(txt) == out, f"failed test for '{path}'"
 
 


### PR DESCRIPTION
Add an option to choose between typographers apostrophe (default) and upright apostrophe, to be used when sanitizing file paths and song artist, title and lyrics, as I requested on #20 

Changing the value has no immediate affect, only when a file is re-downloaded, it changes the folder/file names and the content of the txt. This also works when the file hasn't been changed on USDB side.