### PR TITLE
Db cleanup and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@
   - Vastly improved performance for loading, searching etc.
   - Meta files are still being used, but are upgraded with a unique ID. Therefore,
     initially launching the new release may take some time.
-  - SQLite's FTS5 is used for searching, which works by matching tokens (words). So
-    a search for "beat" matches "Beat It", but not, unlike before, the "The Beatles".
+  - SQLite's FTS5 is used for searching, which works slightly different than the
+    previous approach.
 - The download status column now shows the last sync time.
 - Files are downloaded into temporary folders first for better clean-up, especially if
   the download fails.

--- a/src/usdb_syncer/db/__init__.py
+++ b/src/usdb_syncer/db/__init__.py
@@ -84,6 +84,7 @@ def _validate_schema(connection: sqlite3.Connection) -> None:
         row = connection.execute("SELECT version FROM meta").fetchone()
         if not row or row[0] != SCHEMA_VERSION:
             raise errors.UnknownSchemaError
+    connection.execute("PRAGMA foreign_keys = ON")
 
 
 def connect(db_path: Path | str, trace: bool = False) -> None:
@@ -255,6 +256,11 @@ def delete_all_usdb_songs() -> None:
 def all_local_usdb_songs() -> Iterable[SongId]:
     stmt = "SELECT DISTINCT song_id FROM sync_meta"
     return (SongId(r[0]) for r in _DbState.connection().execute(stmt))
+
+
+def all_song_ids() -> Iterable[SongId]:
+    rows = _DbState.connection().execute("SELECT song_id FROM usdb_song")
+    return (SongId(r[0]) for r in rows)
 
 
 def search_usdb_songs(search: SearchBuilder) -> Iterable[SongId]:

--- a/src/usdb_syncer/db/__init__.py
+++ b/src/usdb_syncer/db/__init__.py
@@ -195,8 +195,8 @@ def _in_ranges_clause(attribute: str, values: list[tuple[int, int | None]]) -> s
 
 
 def _fts5_phrases(text: str) -> str:
-    """Turns each whitespace-separated word into an FTS5 phrase."""
-    return " ".join(f'"{s}"' for s in text.replace('"', "").split(" ") if s)
+    """Turns each whitespace-separated word into an FTS5 prefix phrase."""
+    return " ".join(f'"{s}"*' for s in text.replace('"', "").split(" ") if s)
 
 
 def _fts5_start_phrase(text: str) -> str:

--- a/src/usdb_syncer/db/__init__.py
+++ b/src/usdb_syncer/db/__init__.py
@@ -134,7 +134,10 @@ class SearchBuilder:
 
     def _filters(self) -> Iterator[str]:
         if _fts5_phrases(self.text):
-            yield "fts_usdb_song MATCH ?"
+            yield (
+                "usdb_song.song_id IN (SELECT rowid FROM fts_usdb_song WHERE"
+                " fts_usdb_song MATCH ?)"
+            )
         if self.artists:
             yield _in_values_clause("usdb_song.artist", self.artists)
         if self.titles:

--- a/src/usdb_syncer/db/sql/select_song_id.sql
+++ b/src/usdb_syncer/db/sql/select_song_id.sql
@@ -2,10 +2,9 @@ SELECT
     usdb_song.song_id
 FROM
     usdb_song
-    JOIN fts_usdb_song ON usdb_song.song_id = fts_usdb_song.rowid
     LEFT JOIN active_sync_meta ON usdb_song.song_id = active_sync_meta.song_id
     AND active_sync_meta.rank = 1
-    LEFT JOIN sync_meta ON sync_meta.sync_meta_id = active_sync_meta.sync_meta_id
+    JOIN sync_meta ON sync_meta.sync_meta_id = active_sync_meta.sync_meta_id
     AND usdb_song.song_id = sync_meta.song_id
     LEFT JOIN resource_file AS txt ON txt.kind = 'txt'
     AND sync_meta.sync_meta_id = txt.sync_meta_id

--- a/src/usdb_syncer/db/sql/setup_script.sql
+++ b/src/usdb_syncer/db/sql/setup_script.sql
@@ -57,7 +57,8 @@ CREATE VIRTUAL TABLE fts_usdb_song USING fts5 (
     language,
     edition,
     content = usdb_song,
-    content_rowid = song_id
+    content_rowid = song_id,
+    prefix = '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20'
 );
 
 CREATE TRIGGER fts_usdb_song_insert

--- a/src/usdb_syncer/db/sql/setup_script.sql
+++ b/src/usdb_syncer/db/sql/setup_script.sql
@@ -27,6 +27,7 @@ CREATE TABLE sync_meta (
     meta_tags TEXT NOT NULL,
     pinned BOOLEAN NOT NULL,
     PRIMARY KEY (sync_meta_id),
+    -- necessary for the active_sync_meta foreign key
     UNIQUE (song_id, sync_meta_id),
     UNIQUE (path),
     FOREIGN KEY (song_id) REFERENCES usdb_song (song_id) ON DELETE CASCADE
@@ -52,6 +53,7 @@ CREATE TABLE active_sync_meta (
 
 CREATE VIRTUAL TABLE fts_usdb_song USING fts5 (
     song_id,
+    padded_song_id,
     artist,
     title,
     language,
@@ -69,6 +71,7 @@ INSERT INTO
     fts_usdb_song (
         rowid,
         song_id,
+        padded_song_id,
         artist,
         title,
         language,
@@ -78,6 +81,7 @@ VALUES
     (
         new.song_id,
         new.song_id,
+        printf('%05d', new.song_id),
         new.artist,
         new.title,
         new.language,
@@ -95,6 +99,7 @@ UPDATE
 SET
     rowid = new.song_id,
     song_id = new.song_id,
+    padded_song_id = printf('%05d', new.song_id),
     artist = new.artist,
     title = new.title,
     language = new.language,

--- a/src/usdb_syncer/db/sql/setup_script.sql
+++ b/src/usdb_syncer/db/sql/setup_script.sql
@@ -27,6 +27,7 @@ CREATE TABLE sync_meta (
     meta_tags TEXT NOT NULL,
     pinned BOOLEAN NOT NULL,
     PRIMARY KEY (sync_meta_id),
+    UNIQUE (song_id, sync_meta_id),
     UNIQUE (path),
     FOREIGN KEY (song_id) REFERENCES usdb_song (song_id) ON DELETE CASCADE
 );

--- a/src/usdb_syncer/gui/__init__.py
+++ b/src/usdb_syncer/gui/__init__.py
@@ -69,9 +69,9 @@ def _load_main_window(mw: MainWindow) -> None:
     folder = settings.get_song_dir()
     db.connect(utils.AppPaths.db, trace=bool(os.environ.get("TRACESQL")))
     with db.transaction():
+        song_routines.load_available_songs(force_reload=False)
         song_routines.synchronize_sync_meta_folder(folder)
         sync_meta.SyncMeta.reset_active(folder)
-        song_routines.load_available_songs(force_reload=False)
     mw.tree.populate()
     mw.table.search_songs()
     splash.showMessage("Song database successfully loaded.", color=Qt.GlobalColor.gray)

--- a/src/usdb_syncer/gui/mw.py
+++ b/src/usdb_syncer/gui/mw.py
@@ -13,7 +13,6 @@ from usdb_syncer.constants import Usdb
 from usdb_syncer.gui import gui_utils, progress_bar
 from usdb_syncer.gui.about_dialog import AboutDialog
 from usdb_syncer.gui.debug_console import DebugConsole
-from usdb_syncer.gui.ffmpeg_dialog import check_ffmpeg
 from usdb_syncer.gui.forms.MainWindow import Ui_MainWindow
 from usdb_syncer.gui.meta_tags_dialog import MetaTagsDialog
 from usdb_syncer.gui.progress import run_with_progress

--- a/src/usdb_syncer/gui/mw.py
+++ b/src/usdb_syncer/gui/mw.py
@@ -225,7 +225,13 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def _open_current_song_folder(self) -> None:
         if song := self.table.current_song():
             if song.sync_meta:
-                open_file_explorer(song.sync_meta.path.parent)
+                if song.sync_meta.path.exists():
+                    open_file_explorer(song.sync_meta.path.parent)
+                else:
+                    with db.transaction():
+                        song.remove_sync_meta()
+                    events.SongChanged(song.song_id)
+                    _logger.info("Song does not exist locally anymore.")
             else:
                 _logger.info("Song does not exist locally.")
         else:

--- a/src/usdb_syncer/gui/mw.py
+++ b/src/usdb_syncer/gui/mw.py
@@ -77,7 +77,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
 
     def _setup_toolbar(self) -> None:
         for action, func in (
-            (self.action_songs_download, self._download_selection),
+            (self.action_songs_download, self.table.download_selection),
             (self.action_songs_abort, self.table.abort_selected_downloads),
             (self.action_find_local_songs, self._select_local_songs),
             (self.action_refetch_song_list, self._refetch_song_list),
@@ -96,9 +96,6 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         ):
             action.triggered.connect(func)
 
-    def _download_selection(self) -> None:
-        check_ffmpeg(self, self.table.download_selection)
-
     def _setup_shortcuts(self) -> None:
         gui_utils.set_shortcut("Ctrl+.", self, lambda: DebugConsole(self).show())
 
@@ -107,7 +104,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         self.pushButton_select_song_dir.clicked.connect(self._select_song_dir)
 
     def _setup_buttons(self) -> None:
-        self.button_download.clicked.connect(self._download_selection)
+        self.button_download.clicked.connect(self.table.download_selection)
         self.button_pause.clicked.connect(DownloadManager.set_pause)
 
     def _on_log_filter_changed(self) -> None:

--- a/src/usdb_syncer/gui/song_table/song_table.py
+++ b/src/usdb_syncer/gui/song_table/song_table.py
@@ -49,6 +49,7 @@ class SongTable:
         mw.table_view.selectionModel().currentChanged.connect(
             self._on_current_song_changed
         )
+        events.SongChanged.subscribe(self._on_song_changed)
         self._setup_search_timer()
         events.TreeFilterChanged.subscribe(self._on_tree_filter_changed)
         events.TextFilterChanged.subscribe(self._on_text_filter_changed)
@@ -121,6 +122,10 @@ class SongTable:
 
     ### actions
 
+    def _on_song_changed(self, event: events.SongChanged) -> None:
+        if event.song_id == self.current_song_id():
+            self._on_current_song_changed()
+
     def _on_current_song_changed(self) -> None:
         song = self.current_song()
         for action in self.mw.menu_songs.actions():
@@ -163,10 +168,15 @@ class SongTable:
 
     ### selection model
 
-    def current_song(self) -> UsdbSong | None:
+    def current_song_id(self) -> SongId | None:
         if (idx := self._view.selectionModel().currentIndex()).isValid():
             if ids := self._model.ids_for_indices([idx]):
-                return UsdbSong.get(ids[0])
+                return ids[0]
+        return None
+
+    def current_song(self) -> UsdbSong | None:
+        if (song_id := self.current_song_id()) is not None:
+            return UsdbSong.get(song_id)
         return None
 
     def selected_songs(self) -> Iterator[UsdbSong]:

--- a/src/usdb_syncer/gui/song_table/song_table.py
+++ b/src/usdb_syncer/gui/song_table/song_table.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from functools import partial
 from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator
 
 import send2trash
@@ -19,6 +20,7 @@ from PySide6.QtGui import QCursor
 from PySide6.QtWidgets import QHeaderView, QMenu
 
 from usdb_syncer import SongId, db, events, settings
+from usdb_syncer.gui import ffmpeg_dialog
 from usdb_syncer.gui.song_table.column import Column
 from usdb_syncer.gui.song_table.table_model import TableModel
 from usdb_syncer.logger import get_logger
@@ -61,6 +63,9 @@ class SongTable:
         self._download(self._selected_rows())
 
     def _download(self, rows: Iterable[int]) -> None:
+        ffmpeg_dialog.check_ffmpeg(self.mw, partial(self._download_inner, rows))
+
+    def _download_inner(self, rows: Iterable[int]) -> None:
         to_download: list[UsdbSong] = []
         for song_id in self._model.ids_for_rows(rows):
             song = UsdbSong.get(song_id)

--- a/src/usdb_syncer/song_loader.py
+++ b/src/usdb_syncer/song_loader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import copy
+import shutil
 import tempfile
 import time
 import traceback
@@ -649,7 +650,7 @@ def _persist_tempfiles(ctx: _Context) -> None:
             if target.exists():
                 send2trash.send2trash(target)
                 ctx.logger.debug(f"Trashed existing file: '{target}'.")
-            temp_file.new_path.rename(target)
+            shutil.move(temp_file.new_path, target)
             temp_file.new_path = target
 
 

--- a/src/usdb_syncer/song_routines.py
+++ b/src/usdb_syncer/song_routines.py
@@ -55,6 +55,7 @@ def dump_available_songs(songs: list[UsdbSong], target: Path | None = None) -> N
 
 def synchronize_sync_meta_folder(folder: Path) -> None:
     db_metas = {m.sync_meta_id: m for m in SyncMeta.get_in_folder(folder)}
+    song_ids = set(db.all_song_ids())
     to_upsert: list[SyncMeta] = []
     for path in folder.glob("**/[!.]*.usdb"):
         meta_id = SyncMetaId.from_path(path)
@@ -62,7 +63,7 @@ def synchronize_sync_meta_folder(folder: Path) -> None:
         if meta_id is not None and meta and meta.mtime == utils.get_mtime(path):
             del db_metas[meta_id]
             continue
-        if meta := SyncMeta.try_from_file(path):
+        if (meta := SyncMeta.try_from_file(path)) and meta.song_id in song_ids:
             to_upsert.append(meta)
             if meta.sync_meta_id in db_metas:
                 del db_metas[meta.sync_meta_id]

--- a/src/usdb_syncer/usdb_song.py
+++ b/src/usdb_syncer/usdb_song.py
@@ -115,6 +115,12 @@ class UsdbSong:
         db.delete_usdb_song(self.song_id)
         _UsdbSongCache.remove(self.song_id)
 
+    def remove_sync_meta(self) -> None:
+        if self.sync_meta:
+            self.sync_meta.delete()
+            self.sync_meta = None
+            _UsdbSongCache.remove(self.song_id)
+
     @classmethod
     def delete_all(cls) -> None:
         db.delete_all_usdb_songs()


### PR DESCRIPTION
Even without extra indices, searching by prefix doesn't feel really slower, and prefix indices are in fact doubling the db size. However, since we're still only talking a few MB here, I guess nobody will care and still added them in.

Side note: This affects db creation and requires deleting the old db file.