### PR TITLE
fixes potoken warning for some youtube downloads by updating yt-dlp

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1932,13 +1932,13 @@ test = ["pytest (>=6.0.0)", "setuptools (>=65)"]
 
 [[package]]
 name = "yt-dlp"
-version = "2024.7.25"
+version = "2024.8.6"
 description = "A feature-rich command-line audio/video downloader"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "yt_dlp-2024.7.25-py3-none-any.whl", hash = "sha256:f44b5f33776b4f718900c670fe6e4698fb6fcd426455cd837cf25a1d6d4d9560"},
-    {file = "yt_dlp-2024.7.25.tar.gz", hash = "sha256:7587aa25e236cf7b14bdb9378bbffff51202d901b04202be0cf62cbb56d3b52c"},
+    {file = "yt_dlp-2024.8.6-py3-none-any.whl", hash = "sha256:ab507ff600bd9269ad4d654e309646976778f0e243eaa2f6c3c3214278bb2922"},
+    {file = "yt_dlp-2024.8.6.tar.gz", hash = "sha256:e8551f26bc8bf67b99c12373cc87ed2073436c3437e53290878d0f4b4bb1f663"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
updating dependency `yt-dlp` to latest version `2024.8.6` in order to fix reported warnings `(poToken experiment detected)` and `API returned broken formats (poToken experiment detected). Giving up after 3 retries` when downloading certain usdb IDs (e.g. `22115`, `22084`, `22063`)

```
2024-08-12 18:54:30 [DEBUG] Get request for https://usdb.animux.de/index.php
2024-08-12 18:54:31 [INFO] #22063: Found 'Avicii feat. Sandro Cavazza - Without You' on USDB.
2024-08-12 18:54:31 [DEBUG] #22063: fetching notes
2024-08-12 18:54:31 [DEBUG] Post request for https://usdb.animux.de/index.php
2024-08-12 18:54:31 [DEBUG] #22063: FIX: Linebreaks corrected.
2024-08-12 18:54:31 [DEBUG] #22063: FIX: Inter-word spaces corrected.
[youtube] Extracting URL: https://www.youtube.com/watch?v=WRz2MxhAdJo
[youtube] WRz2MxhAdJo: Downloading webpage
WARNING: [youtube] Webpage contains broken formats (poToken experiment detected). Ignoring initial player response
[youtube] WRz2MxhAdJo: Downloading ios player API JSON
[youtube] WRz2MxhAdJo: Downloading player 1c78e434
[youtube] WRz2MxhAdJo: Downloading web player API JSON
WARNING: [youtube] API returned broken formats (poToken experiment detected). Retrying (1/3)...
[youtube] WRz2MxhAdJo: Downloading web player API JSON
WARNING: [youtube] API returned broken formats (poToken experiment detected). Retrying (2/3)...
[youtube] WRz2MxhAdJo: Downloading web player API JSON
WARNING: [youtube] API returned broken formats (poToken experiment detected). Retrying (3/3)...
[youtube] WRz2MxhAdJo: Downloading web player API JSON
WARNING: [youtube] API returned broken formats (poToken experiment detected). Giving up after 3 retries
[youtube] WRz2MxhAdJo: Downloading m3u8 information
[info] WRz2MxhAdJo: Downloading 1 format(s): 140
[download] Destination: C:\Users\%USERNAME%\AppData\Local\Temp\tmpzfsw6zfk\Avicii feat. Sandro Cavazza - Without You.m4a
[download] 100% of    2.83MiB in 00:00:00 at 3.73MiB/s
```