### PR TITLE
fixes typo in readme corrupting markdown rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@
 The project [extensively uses the `#VIDEO` tag](https://github.com/bohning/usdb_syncer/wiki/Meta-Tags#format) to automaticly retrieve the resources (audio, video, images, etc...) to make the UltraStar song complete.
 Once a song is downloaded it can be synchronized (new notes, audio, video, images...) by redownloading the song. If a resource didn't change it's skipped.
 
-````
-
 ## Development
 
 **USDB Syncer** is written in Python, and uses Poetry to manage its dependencies.
@@ -31,7 +29,7 @@ Clone the project:
 ```bash
 git clone https://github.com/bohning/usdb_syncer.git
 cd usdb_syncer
-````
+```
 
 Additionally requires extra packages when developing **on Linux**:
 


### PR DESCRIPTION
fixes typo in the readme from

![grafik](https://github.com/user-attachments/assets/c8137702-cf5d-4aef-b64c-ccf3a41f6f1b)

to

![grafik](https://github.com/user-attachments/assets/4065c614-6548-4570-8699-8047933a4951)


