### PR TITLE
Allow users to run custom commands after download

### DIFF
--- a/src/usdb_syncer/download_options.py
+++ b/src/usdb_syncer/download_options.py
@@ -63,6 +63,13 @@ class BackgroundOptions:
 
 
 @dataclass(frozen=True)
+class CommandOptions:
+    """Settings regarding the command to be executed."""
+
+    command: settings.Command
+
+
+@dataclass(frozen=True)
 class Options:
     """Settings for downloading songs."""
 
@@ -74,6 +81,7 @@ class Options:
     video_options: VideoOptions | None
     cover: CoverOptions | None
     background_options: BackgroundOptions | None
+    command_options: CommandOptions | None
 
 
 def download_options() -> Options:
@@ -86,6 +94,7 @@ def download_options() -> Options:
         video_options=_video_options(),
         cover=_cover_options(),
         background_options=_background_options(),
+        command_options=_command_options(),
     )
 
 
@@ -129,3 +138,9 @@ def _background_options() -> BackgroundOptions | None:
     if not settings.get_background():
         return None
     return BackgroundOptions(even_with_video=settings.get_background_always())
+
+
+def _command_options() -> CommandOptions | None:
+    if not settings.get_command():
+        return None
+    return CommandOptions(command=settings.get_command())

--- a/src/usdb_syncer/download_options.py
+++ b/src/usdb_syncer/download_options.py
@@ -66,7 +66,7 @@ class BackgroundOptions:
 class CommandOptions:
     """Settings regarding the command to be executed."""
 
-    command: settings.Command
+    command: str
 
 
 @dataclass(frozen=True)
@@ -143,4 +143,4 @@ def _background_options() -> BackgroundOptions | None:
 def _command_options() -> CommandOptions | None:
     if not settings.get_command():
         return None
-    return CommandOptions(command=settings.get_command())
+    return CommandOptions(command=settings.get_command_text())

--- a/src/usdb_syncer/gui/forms/SettingsDialog.ui
+++ b/src/usdb_syncer/gui/forms/SettingsDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>532</width>
-    <height>485</height>
+    <height>524</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,24 +24,11 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Policy::Fixed</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="0" rowspan="2">
+   <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
+     <property name="mouseTracking">
+      <bool>true</bool>
+     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
@@ -52,6 +39,9 @@
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0">
+         <property name="sizeConstraint">
+          <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
+         </property>
          <item>
           <widget class="QGroupBox" name="groupBox_login">
            <property name="title">
@@ -217,13 +207,25 @@
          <item>
           <widget class="QGroupBox" name="groupBox_command">
            <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
              <horstretch>0</horstretch>
-             <verstretch>100</verstretch>
+             <verstretch>0</verstretch>
             </sizepolicy>
+           </property>
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+           <property name="layoutDirection">
+            <enum>Qt::LayoutDirection::LeftToRight</enum>
            </property>
            <property name="title">
             <string>Run command after downloading</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
            <property name="checkable">
             <bool>true</bool>
@@ -231,25 +233,36 @@
            <property name="checked">
             <bool>false</bool>
            </property>
-           <widget class="QPlainTextEdit" name="textEdit_command">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="geometry">
-             <rect>
-              <x>10</x>
-              <y>20</y>
-              <width>271</width>
-              <height>20</height>
-             </rect>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
+           <layout class="QFormLayout" name="formLayout_8">
+            <item row="0" column="0">
+             <widget class="QPlainTextEdit" name="textEdit_command">
+              <property name="enabled">
+               <bool>true</bool>
+              </property>
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>256</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="cursor" stdset="0">
+               <cursorShape>IBeamCursor</cursorShape>
+              </property>
+              <property name="acceptDrops">
+               <bool>false</bool>
+              </property>
+              <property name="placeholderText">
+               <string>Use &quot;$dir$&quot; to specify path to song folder</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
          </item>
         </layout>
@@ -558,6 +571,22 @@
       </layout>
      </widget>
     </widget>
+   </item>
+   <item row="1" column="0" rowspan="2">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Policy::MinimumExpanding</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/usdb_syncer/gui/forms/SettingsDialog.ui
+++ b/src/usdb_syncer/gui/forms/SettingsDialog.ui
@@ -24,7 +24,23 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
+   <item row="2" column="0">
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Orientation::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Policy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0" rowspan="2">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -35,7 +51,7 @@
       </attribute>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0">
+        <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,0,0,0">
          <item>
           <widget class="QGroupBox" name="groupBox_login">
            <property name="title">
@@ -196,6 +212,44 @@
              </widget>
             </item>
            </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox_command">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+             <horstretch>0</horstretch>
+             <verstretch>100</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>Run command after downloading</string>
+           </property>
+           <property name="checkable">
+            <bool>true</bool>
+           </property>
+           <property name="checked">
+            <bool>false</bool>
+           </property>
+           <widget class="QPlainTextEdit" name="textEdit_command">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="geometry">
+             <rect>
+              <x>10</x>
+              <y>20</y>
+              <width>271</width>
+              <height>20</height>
+             </rect>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
           </widget>
          </item>
         </layout>
@@ -504,19 +558,6 @@
       </layout>
      </widget>
     </widget>
-   </item>
-   <item row="2" column="0">
-    <spacer name="verticalSpacer_2">
-     <property name="orientation">
-      <enum>Qt::Orientation::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/usdb_syncer/gui/settings_dialog.py
+++ b/src/usdb_syncer/gui/settings_dialog.py
@@ -100,7 +100,8 @@ class SettingsDialog(Ui_Dialog, QDialog):
         self.groupBox_background.setChecked(settings.get_background())
         self.checkBox_background_always.setChecked(settings.get_background_always())
 
-        self.textEdit_command.setPlainText(settings.get_command())
+        self.groupBox_command.setChecked(settings.get_command())
+        self.textEdit_command.setPlainText(str(settings.get_command_text()))
 
     def _setup_path_template(self) -> None:
         self.edit_path_template.textChanged.connect(self._on_path_template_changed)
@@ -154,7 +155,8 @@ class SettingsDialog(Ui_Dialog, QDialog):
         settings.set_video_fps(self.comboBox_fps.currentData())
         settings.set_background(self.groupBox_background.isChecked())
         settings.set_background_always(self.checkBox_background_always.isChecked())
-        settings.set_command(self.textEdit_command.toPlainText())
+        settings.set_command(self.groupBox_command.isChecked())
+        settings.set_command_text(self.textEdit_command.toPlainText())
         if self._path_template:
             settings.set_path_template(self._path_template)
         else:

--- a/src/usdb_syncer/gui/settings_dialog.py
+++ b/src/usdb_syncer/gui/settings_dialog.py
@@ -100,6 +100,8 @@ class SettingsDialog(Ui_Dialog, QDialog):
         self.groupBox_background.setChecked(settings.get_background())
         self.checkBox_background_always.setChecked(settings.get_background_always())
 
+        self.textEdit_command.setPlainText(settings.get_command())
+
     def _setup_path_template(self) -> None:
         self.edit_path_template.textChanged.connect(self._on_path_template_changed)
         self.edit_path_template.setText(str(settings.get_path_template()))
@@ -152,6 +154,7 @@ class SettingsDialog(Ui_Dialog, QDialog):
         settings.set_video_fps(self.comboBox_fps.currentData())
         settings.set_background(self.groupBox_background.isChecked())
         settings.set_background_always(self.checkBox_background_always.isChecked())
+        settings.set_command(self.textEdit_command.toPlainText())
         if self._path_template:
             settings.set_path_template(self._path_template)
         else:

--- a/src/usdb_syncer/run_command.py
+++ b/src/usdb_syncer/run_command.py
@@ -6,30 +6,60 @@ from pathlib import Path
 from usdb_syncer.logger import Log
 
 
-def run_command(command: str, directory: Path, logger: Log) -> int:
-    """Run a command on the local machine.
+def run_command(
+    command: str, directory: Path, logger: Log, timeout: float | None = None
+) -> int:
+    """
+    Run a command on the local machine. The placeholder $dir$ in the command will be replaced with the specified directory.
+    The working directory will be set to the parent of the provided directory.
 
     Parameters:
-        command: the command to run. $dir$ will be replaced with the directory.
-        directory: the directory to run the command in
-        logger: the logger to use
+        command (str): The command to run. The placeholder $dir$ will be replaced with the directory.
+        directory (Path): The directory to replace $dir$ with. Intended to be the directory of the song.
+        logger (Log): The logger to use for logging messages.
 
     Returns:
-        the return code of the command
+        int: The return code of the command. Returns 0 if there is no command to run.
     """
-    logger.info("Running supplied command.")
+    if command == "":
+        logger.debug("No command set to to run.")
+        return 0
 
-    args: list[str] = []
+    logger.info("Running custom command.")
 
-    # Insert directory where $dir$ is found in the command
-    args = command.split(" ")
-    if "$dir$" in command:
-        args[args.index("$dir$")] = str(directory)
+    # Build the command
+    parts = command.split(" ")
+    args = []
+    for arg in parts:
+        if arg.count("$dir$") > 0:
+            logger.debug(f"Replacing $dir$ with {directory}.")
+            arg = arg.replace("$dir$", str(directory))
+        args.append(arg)
 
-    logger.debug(f"Running command '{args}' in '{directory}'.")
+    logger.debug(
+        f'Running custom command "{" ".join(args)}" in "{directory.parent}".'
+    )  # e.g Running command "echo hello" in "/home/user/songs".
 
-    p = subprocess.run(args=args, cwd=directory, shell=True)
+    try:
+        p = subprocess.run(
+            args=args, cwd=directory.parent, shell=True, check=True, timeout=timeout
+        )
+    except ValueError:
+        logger.error("Custom command is invalid.")
+        return 1
+    except OSError:
+        logger.error(
+            "Running custom command failed because a shell could not be invoked."
+        )
+        return 1
+    except subprocess.TimeoutExpired:
+        logger.error("Custom command timed out.")
+        return 1
+    except subprocess.CalledProcessError as e:
+        logger.error(
+            f"Custom command failed while running with error code: {e.returncode}"
+        )
+        return e.returncode
 
-    if p.returncode != 0:
-        logger.error(f"Command failed with return code {p.returncode}")
+    logger.info("Custom command ran successfully.")
     return p.returncode

--- a/src/usdb_syncer/run_command.py
+++ b/src/usdb_syncer/run_command.py
@@ -1,0 +1,36 @@
+"""Functions for running commands on the local machine."""
+
+import subprocess
+import os
+from pathlib import Path
+
+from usdb_syncer.logger import Log
+
+
+def run_command(command: str, directory: Path, logger: Log) -> int:
+    """Run a command on the local machine.
+
+    Parameters:
+        command: the command to run
+        args: the arguments to pass to the command
+        logger: the logger to use
+
+    Returns:
+        the return code of the command
+    """
+    logger.info("Running supplied command.")
+
+    args: list[str] = []
+
+    # Insert directory where $dir$ is found in the command
+    args = command.split(" ")
+    if "$dir$" in command:
+        args[args.index("$dir$")] = str(directory)
+
+    logger.debug(f"Running command '{args}' in '{directory}'.")
+
+    p = subprocess.run(args=args, cwd=directory, shell=True)
+
+    if p.returncode != 0:
+        logger.error(f"Command failed with return code {p.returncode}")
+    return p.returncode

--- a/src/usdb_syncer/run_command.py
+++ b/src/usdb_syncer/run_command.py
@@ -45,19 +45,21 @@ def run_command(
             args=args, cwd=directory.parent, shell=True, check=True, timeout=timeout
         )
     except ValueError:
-        logger.error("Custom command is invalid.")
+        logger.error("Custom command is invalid.", exc_info=False)
         return 1
     except OSError:
         logger.error(
-            "Running custom command failed because a shell could not be invoked."
+            "Running custom command failed because a shell could not be invoked.",
+            exc_info=False,
         )
         return 1
     except subprocess.TimeoutExpired:
-        logger.error("Custom command timed out.")
+        logger.error("Custom command timed out.", exc_info=False)
         return 1
     except subprocess.CalledProcessError as e:
         logger.error(
-            f"Custom command failed while running with error code: {e.returncode}"
+            f"Custom command failed while running with error code: {e.returncode}",
+            exc_info=False,
         )
         return e.returncode
 

--- a/src/usdb_syncer/run_command.py
+++ b/src/usdb_syncer/run_command.py
@@ -1,7 +1,6 @@
 """Functions for running commands on the local machine."""
 
 import subprocess
-import os
 from pathlib import Path
 
 from usdb_syncer.logger import Log
@@ -11,8 +10,8 @@ def run_command(command: str, directory: Path, logger: Log) -> int:
     """Run a command on the local machine.
 
     Parameters:
-        command: the command to run
-        args: the arguments to pass to the command
+        command: the command to run. $dir$ will be replaced with the directory.
+        directory: the directory to run the command in
         logger: the logger to use
 
     Returns:

--- a/src/usdb_syncer/settings.py
+++ b/src/usdb_syncer/settings.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 import os
 import shutil
 import traceback
-from dataclasses import dataclass
 from enum import Enum
 from http.cookiejar import CookieJar
 from pathlib import Path
@@ -89,6 +88,7 @@ class SettingKey(Enum):
     BACKGROUND = "downloads/background"
     BACKGROUND_ALWAYS = "downloads/background_always"
     COMMAND = "downloads/command"
+    COMMANDTEXT = "downloads/command_text"
     MAIN_WINDOW_GEOMETRY = "geometry/main_window"
     DOCK_LOG_GEOMETRY = "geometry/dock_log"
     MAIN_WINDOW_STATE = "state/main_window"
@@ -438,13 +438,6 @@ class VideoFps(Enum):
         return str(self.value)
 
 
-@dataclass(frozen=True)
-class Command:
-    """Command to execute."""
-
-    command: str = ""
-
-
 T = TypeVar("T")
 
 
@@ -642,12 +635,20 @@ def set_ffmpeg_dir(value: str) -> None:
     set_setting(SettingKey.FFMPEG_DIR, value)
 
 
-def get_command() -> Command:
-    return get_setting(SettingKey.COMMAND, Command.command)
+def get_command() -> bool:
+    return get_setting(SettingKey.COMMAND, False)
 
 
-def set_command(value: Command) -> None:
+def set_command(value: bool) -> None:
     set_setting(SettingKey.COMMAND, value)
+
+
+def get_command_text() -> str:
+    return get_setting(SettingKey.COMMANDTEXT, "")
+
+
+def set_command_text(value: str) -> None:
+    set_setting(SettingKey.COMMANDTEXT, value)
 
 
 def get_geometry_main_window() -> QByteArray:

--- a/src/usdb_syncer/settings.py
+++ b/src/usdb_syncer/settings.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import shutil
 import traceback
+from dataclasses import dataclass
 from enum import Enum
 from http.cookiejar import CookieJar
 from pathlib import Path
@@ -87,6 +88,7 @@ class SettingKey(Enum):
     COVER_MAX_SIZE = "downloads/cover_max_size"
     BACKGROUND = "downloads/background"
     BACKGROUND_ALWAYS = "downloads/background_always"
+    COMMAND = "downloads/command"
     MAIN_WINDOW_GEOMETRY = "geometry/main_window"
     DOCK_LOG_GEOMETRY = "geometry/dock_log"
     MAIN_WINDOW_STATE = "state/main_window"
@@ -436,6 +438,13 @@ class VideoFps(Enum):
         return str(self.value)
 
 
+@dataclass(frozen=True)
+class Command:
+    """Command to execute."""
+
+    command: str = ""
+
+
 T = TypeVar("T")
 
 
@@ -631,6 +640,14 @@ def get_ffmpeg_dir() -> str:
 
 def set_ffmpeg_dir(value: str) -> None:
     set_setting(SettingKey.FFMPEG_DIR, value)
+
+
+def get_command() -> Command:
+    return get_setting(SettingKey.COMMAND, Command.command)
+
+
+def set_command(value: Command) -> None:
+    set_setting(SettingKey.COMMAND, value)
 
 
 def get_geometry_main_window() -> QByteArray:

--- a/src/usdb_syncer/song_loader.py
+++ b/src/usdb_syncer/song_loader.py
@@ -728,12 +728,11 @@ def _write_sync_meta(ctx: _Context) -> None:
 
 
 def _run_command(ctx: _Context) -> None:
-    # Run command if set
-    command = str(ctx.options.command_options.command)
-    if command is None:
+    if not ctx.options.command_options:
         return
+
+    command = str(ctx.options.command_options.command)
+
     run_command.run_command(
-        command=command,
-        directory=ctx.locations.target_path().parent,
-        logger=ctx.logger,
+        command=command, directory=ctx.locations.target_path().parent, logger=ctx.logger
     )

--- a/src/usdb_syncer/song_loader.py
+++ b/src/usdb_syncer/song_loader.py
@@ -31,6 +31,7 @@ from usdb_syncer import (
     errors,
     events,
     resource_dl,
+    run_command,
     usdb_scraper,
     utils,
 )
@@ -391,6 +392,7 @@ class _SongLoader(QtCore.QRunnable):
             ctx.locations.move_to_target_folder()
             _persist_tempfiles(ctx)
         _write_sync_meta(ctx)
+        _run_command(ctx)
         return ctx.song
 
     def _check_flags(self) -> None:
@@ -723,3 +725,15 @@ def _write_sync_meta(ctx: _Context) -> None:
         ctx.locations, temp=False
     )
     ctx.song.sync_meta.synchronize_to_file()
+
+
+def _run_command(ctx: _Context) -> None:
+    # Run command if set
+    command = str(ctx.options.command_options.command)
+    if command is None:
+        return
+    run_command.run_command(
+        command=command,
+        directory=ctx.locations.target_path().parent,
+        logger=ctx.logger,
+    )


### PR DESCRIPTION
This PR adds the ability to run a user-set command after the song has downloaded. This enables the syncer to be infinitely customizable at a users whim, for example, being able to split songs with AI or transcode videos to a more efficient codec.

![settings screenshot](https://github.com/user-attachments/assets/2f47aa9d-9aad-43f0-ba1e-e48389a82a1b)

# Usage
A new setting with a plain text field allows entering the command. In the user-set command, occurrences of "$dir$" (writing this, I am not convinced of that name) will be replaced by the song folder that was just downloaded. The command is executed in the global song directory. A user could create a batch file there with the song folder as an argument, and write everything else in the batch file.

# Example Usage
I want to split my songs with [demucs](https://github.com/facebookresearch/demucs). Unfortunately, I could not get it to work with cuda in python3.12. The only thing I managed was to pin the torch dependencies to specific releases and use python3.11 for the project. This makes running that from python3.12 a pain. With this feature, I can write a little batch script that just passes the song folder to my program and launches it with poetry correctly (i could also enter the poetry command in the settings), therefore bypassing many requirements I assume are being written in the instrumental-version branch, for example actually installing the cuda drivers, and using the correct torch dependancy, because the cuda version of torch obviously doesn't work for users that don't have an nvidia graphics card. This feature allows users like me to take some of that responsibility, which definitely doesn't work for everyone, but greatly improves the experience those that can take advantage of it. 

# Implementation details
I decided not to write stdout of the command to the log, because that seemed like a great idea for completely spamming the log. The return code of the command is written to the log as an info, so there is that for communication. Otherwise, I've tried to include as much information about execution into the log, so there shouldn't be any confusion there. 

Regarding security, I don't think there is any need to consider it. We are only running a user-supplied command, at the same execution level as the rest of the syncer.