### PR TITLE
PathTemplate - retrieve first value of Genre, Language, Creator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ venv
 # IDEs
 .qt_for_python
 .vscode
+.vs
 
 # tooling
 .tox

--- a/src/usdb_syncer/path_template.py
+++ b/src/usdb_syncer/path_template.py
@@ -163,13 +163,16 @@ class PathTemplatePlaceholder(PathTemplateComponentToken, enum.Enum):
             case PathTemplatePlaceholder.TITLE:
                 return song.title
             case PathTemplatePlaceholder.GENRE:
-                return song.genre
+                firstGenre, _, _ = song.genre.partition(',')
+                return firstGenre.strip()
             case PathTemplatePlaceholder.YEAR:
                 return str(song.year)
             case PathTemplatePlaceholder.LANGUAGE:
-                return song.language
+                firstLanguage, _, _ = song.language.partition(',')
+                return firstLanguage.strip()
             case PathTemplatePlaceholder.CREATOR:
-                return song.creator
+                firstCreator, _, _ = song.creator.partition(',')
+                return firstCreator.strip()
             case PathTemplatePlaceholder.EDITION:
                 return song.edition
             case PathTemplatePlaceholder.RATING:

--- a/src/usdb_syncer/path_template.py
+++ b/src/usdb_syncer/path_template.py
@@ -163,16 +163,16 @@ class PathTemplatePlaceholder(PathTemplateComponentToken, enum.Enum):
             case PathTemplatePlaceholder.TITLE:
                 return song.title
             case PathTemplatePlaceholder.GENRE:
-                firstGenre, _, _ = song.genre.partition(",")
-                return firstGenre.strip()
+                first_genre, _, _ = song.genre.partition(",")
+                return first_genre.strip()
             case PathTemplatePlaceholder.YEAR:
                 return str(song.year)
             case PathTemplatePlaceholder.LANGUAGE:
-                firstLanguage, _, _ = song.language.partition(",")
-                return firstLanguage.strip()
+                first_language, _, _ = song.language.partition(",")
+                return first_language.strip()
             case PathTemplatePlaceholder.CREATOR:
-                firstCreator, _, _ = song.creator.partition(",")
-                return firstCreator.strip()
+                first_creator, _, _ = song.creator.partition(",")
+                return first_creator.strip()
             case PathTemplatePlaceholder.EDITION:
                 return song.edition
             case PathTemplatePlaceholder.RATING:

--- a/src/usdb_syncer/path_template.py
+++ b/src/usdb_syncer/path_template.py
@@ -163,15 +163,15 @@ class PathTemplatePlaceholder(PathTemplateComponentToken, enum.Enum):
             case PathTemplatePlaceholder.TITLE:
                 return song.title
             case PathTemplatePlaceholder.GENRE:
-                firstGenre, _, _ = song.genre.partition(',')
+                firstGenre, _, _ = song.genre.partition(",")
                 return firstGenre.strip()
             case PathTemplatePlaceholder.YEAR:
                 return str(song.year)
             case PathTemplatePlaceholder.LANGUAGE:
-                firstLanguage, _, _ = song.language.partition(',')
+                firstLanguage, _, _ = song.language.partition(",")
                 return firstLanguage.strip()
             case PathTemplatePlaceholder.CREATOR:
-                firstCreator, _, _ = song.creator.partition(',')
+                firstCreator, _, _ = song.creator.partition(",")
                 return firstCreator.strip()
             case PathTemplatePlaceholder.EDITION:
                 return song.edition

--- a/src/usdb_syncer/path_template.py
+++ b/src/usdb_syncer/path_template.py
@@ -163,16 +163,13 @@ class PathTemplatePlaceholder(PathTemplateComponentToken, enum.Enum):
             case PathTemplatePlaceholder.TITLE:
                 return song.title
             case PathTemplatePlaceholder.GENRE:
-                first_genre, _, _ = song.genre.partition(",")
-                return first_genre.strip()
+                return next(iter(song.genres()), "")
             case PathTemplatePlaceholder.YEAR:
                 return str(song.year)
             case PathTemplatePlaceholder.LANGUAGE:
-                first_language, _, _ = song.language.partition(",")
-                return first_language.strip()
+                return next(iter(song.languages()), "")
             case PathTemplatePlaceholder.CREATOR:
-                first_creator, _, _ = song.creator.partition(",")
-                return first_creator.strip()
+                return next(iter(song.creators()), "")
             case PathTemplatePlaceholder.EDITION:
                 return song.edition
             case PathTemplatePlaceholder.RATING:


### PR DESCRIPTION
### Description
Retrieves either the first value or the whole string when no comma seperator has been found.

Using `partition()` instead of index-accessor + split since we don't need the rest of the string and this way we cannot go out of bounds if there is not match found.

### Usecase

I'm having a path-template setup like:
```
:language: / :artist: / :artist: - :title: / :artist: - :title:
```
For this [song](https://usdb.animux.de/?link=detail&id=29243) it results into
```
Japanese (romanized), English\Jujutsu Kaisen (ALI feat. AKLO)\Jujutsu Kaisen (ALI feat. AKLO) - Lost In Paradise (TV)\Jujutsu Kaisen (ALI feat.txt
```
With this fix it turns out to be:
```
Japanese (romanized)\Jujutsu Kaisen (ALI feat. AKLO)\Jujutsu Kaisen (ALI feat. AKLO) - Lost In Paradise (TV)\Jujutsu Kaisen (ALI feat.txt
```

It'd be nice to only keep the first entry of the comma-seperated list as path modifier.

It applies to the 3 mentioned fields: Genre, Language and Creator