### PR TITLE
Allow exclusion of VP9 codec for mp4 video containers.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
     are found on USDB.
 - Comments can now be posted on songs. Each comment includes a message and a rating. 
   Ratings can be negative, neutral, or positive, with neutral being the default.
+- The VP9 codec can be excluded for mp4 video containers (see _Settings_).
 
 ## Developer notes
 

--- a/src/usdb_syncer/settings.py
+++ b/src/usdb_syncer/settings.py
@@ -336,24 +336,33 @@ class VideoContainer(Enum):
     """Video containers that can be requested when downloading with ytdl."""
 
     MP4 = "mp4"
+    MP4_NO_VP9 = "mp4_no_vp9"
     WEBM = "webm"
     BEST = "bestvideo"
 
     def __str__(self) -> str:
         match self:
             case VideoContainer.MP4:
-                return ".mp4"
+                return ".mp4 (any codec)"
+            case VideoContainer.MP4_NO_VP9:
+                return ".mp4 (no VP9)"
             case VideoContainer.WEBM:
-                return ".webm"
+                return ".webm (VP9)"
             case VideoContainer.BEST:
                 return "Best available"
             case _ as unreachable:
                 assert_never(unreachable)
 
     def ytdl_format(self) -> str:
-        if self is VideoContainer.BEST:
-            return "bestvideo*"
-        return f"bestvideo*[ext={self.value}]"
+        match self:
+            case VideoContainer.MP4 | VideoContainer.WEBM:
+                return f"bestvideo*[ext={self.value}]"
+            case VideoContainer.MP4_NO_VP9:
+                return "bestvideo*[ext=mp4][vcodec!~='vp0?9']"
+            case VideoContainer.BEST:
+                return "bestvideo*"
+            case _ as unreachable:
+                assert_never(unreachable)
 
 
 class VideoCodec(Enum):


### PR DESCRIPTION
For reference: https://github.com/yt-dlp/yt-dlp/issues/7846