### PR TITLE
Bugfixes

### DIFF
--- a/src/usdb_syncer/gui/forms/SettingsDialog.ui
+++ b/src/usdb_syncer/gui/forms/SettingsDialog.ui
@@ -416,6 +416,9 @@
             </item>
             <item row="3" column="0">
              <widget class="QLabel" name="label_video_embed_artwork">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
               <property name="text">
                <string>Embed artwork:</string>
               </property>
@@ -423,6 +426,9 @@
             </item>
             <item row="3" column="1">
              <widget class="QCheckBox" name="checkBox_video_embed_artwork">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
               <property name="text">
                <string/>
               </property>

--- a/src/usdb_syncer/gui/settings_dialog.py
+++ b/src/usdb_syncer/gui/settings_dialog.py
@@ -39,6 +39,8 @@ class SettingsDialog(Ui_Dialog, QDialog):
         self._load_settings()
         self._setup_path_template()
         self._browser = self.comboBox_browser.currentData()
+        self.label_video_embed_artwork.setVisible(False)
+        self.checkBox_video_embed_artwork.setVisible(False)
         self.groupBox_reencode_video.setVisible(False)
 
     def _populate_comboboxes(self) -> None:

--- a/src/usdb_syncer/settings.py
+++ b/src/usdb_syncer/settings.py
@@ -108,9 +108,9 @@ class Encoding(Enum):
             case Encoding.UTF_8:
                 return "UTF-8"
             case Encoding.UTF_8_BOM:
-                return "UTF-8 BOM"
+                return "UTF-8 BOM (legacy support for older Vocaluxe versions)"
             case Encoding.CP1252:
-                return "CP1252"
+                return "CP1252 (legacy support for older USDX CMD)"
             case _ as unreachable:
                 assert_never(unreachable)
 

--- a/src/usdb_syncer/song_loader.py
+++ b/src/usdb_syncer/song_loader.py
@@ -301,7 +301,7 @@ def _get_usdb_data(song_id: SongId, logger: Log) -> tuple[SongDetails, SongTxt]:
     txt = SongTxt.parse(txt_str, logger)
     txt.sanitize()
     txt.headers.creator = txt.headers.creator or details.uploader or None
-    txt.headers.tags = ", ".join(details.comment_tags())
+    txt.headers.tags = ", ".join(details.comment_tags()) or None
     return details, txt
 
 


### PR DESCRIPTION
Some small bugfixes/improvements:
- #TAGS is now only written to the text file if it is not empty (we should probably migrate to a `tags=` metatag now with the basically unlimited line length on USDB)
- Add some explanatory text to the legacy support text encoding options UTF-8 BOM and CP1252
- Disable and hide the recently introduced option to add artwork to mp4 as this produces video files that are currently not playable by USDX