### PR TITLE
Context hook

### DIFF
--- a/src/usdb_syncer/hooks.py
+++ b/src/usdb_syncer/hooks.py
@@ -8,6 +8,7 @@ import attrs
 
 if TYPE_CHECKING:
     from usdb_syncer import usdb_song
+    from usdb_syncer.song_loader import _Context
 
 # pylint currently lacks support for ParamSpec
 # https://github.com/pylint-dev/pylint/issues/9424
@@ -45,3 +46,11 @@ class SongLoaderDidFinish(_Hook):
     @classmethod
     def call(cls, song: usdb_song.UsdbSong) -> None:
         super().call(song)
+
+
+class SongLoaderContextDidFinish(_Hook):
+    """Called after song download as part of the download context."""
+
+    @classmethod
+    def call(cls, ctx: _Context) -> None:
+        super().call(ctx)

--- a/src/usdb_syncer/song_loader.py
+++ b/src/usdb_syncer/song_loader.py
@@ -383,6 +383,7 @@ class _SongLoader(QtCore.QRunnable):
             ctx.locations.move_to_target_folder()
             _persist_tempfiles(ctx)
         _write_sync_meta(ctx)
+        hooks.SongLoaderContextDidFinish.call(ctx)
         hooks.SongLoaderDidFinish.call(ctx.song)
         return ctx.song
 


### PR DESCRIPTION
Hey, sorry for not responding to #283 . I've had a busy couple of months.

I'd love to have the `_Context` available to an addon. This would allow access to the `SongLogger` for clearer logging. I'm not quite happy with the implementation I came up with, especially the name, however, it doesn't break the existing hook. An alternative would be to just change the existing hook from `UsdbSong` to `_Context`, or to add an additional `SongLogger` argument. Of course, external access to `_Context` isn't very clean, so refactoring `_Context` to `Context` would be better if needed.

A different point of discussion could be placing the call to `SongLoaderContextDidFinish` before the files are moved to their final destination, i.e allowing addons to work within the temporary directories. It would probably make a bit more sense from a conceptual point of view if the addon intends to modify existing files. That would need to be communicated somehow though.

Happy to have a discussion.