### PR TITLE
Add configurable rate limit for yt-dlp.

### DIFF
--- a/src/usdb_syncer/download_options.py
+++ b/src/usdb_syncer/download_options.py
@@ -27,6 +27,7 @@ class AudioOptions:
     bitrate: settings.AudioBitrate
     normalize: bool
     embed_artwork: bool
+    rate_limit: settings.YtdlpRateLimit
 
     def ytdl_format(self) -> str:
         return self.format.ytdl_format()
@@ -41,6 +42,7 @@ class VideoOptions:
     max_resolution: settings.VideoResolution
     max_fps: settings.VideoFps
     embed_artwork: bool
+    rate_limit: settings.YtdlpRateLimit
 
     def ytdl_format(self) -> str:
         fmt = self.format.ytdl_format()
@@ -117,6 +119,7 @@ def _audio_options() -> AudioOptions | None:
         bitrate=settings.get_audio_bitrate(),
         normalize=settings.get_audio_normalize(),
         embed_artwork=settings.get_audio_embed_artwork(),
+        rate_limit=settings.get_ytdlp_rate_limit(),
     )
 
 
@@ -131,6 +134,7 @@ def _video_options() -> VideoOptions | None:
         max_resolution=settings.get_video_resolution(),
         max_fps=settings.get_video_fps(),
         embed_artwork=settings.get_video_embed_artwork(),
+        rate_limit=settings.get_ytdlp_rate_limit(),
     )
 
 

--- a/src/usdb_syncer/gui/forms/SettingsDialog.ui
+++ b/src/usdb_syncer/gui/forms/SettingsDialog.ui
@@ -32,7 +32,7 @@
          <item>
           <widget class="QGroupBox" name="groupBox_login">
            <property name="title">
-            <string>USDB and Youtube login</string>
+            <string>Login cookies (USDB and Youtube)</string>
            </property>
            <layout class="QGridLayout" name="gridLayout_3">
             <item row="0" column="0">
@@ -41,7 +41,7 @@
                <string/>
               </property>
               <property name="text">
-               <string>Browser cookies:</string>
+               <string>Browser:</string>
               </property>
              </widget>
             </item>
@@ -282,6 +282,25 @@
        <item>
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
+          <widget class="QGroupBox" name="groupBox_2">
+           <property name="title">
+            <string>yt-dlp</string>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_10">
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_ytdlp_rate_limit">
+              <property name="text">
+               <string>Rate limit:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QComboBox" name="comboBox_ytdlp_rate_limit"/>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
           <widget class="QGroupBox" name="groupBox_audio">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -296,6 +315,20 @@
             <bool>true</bool>
            </property>
            <layout class="QGridLayout" name="gridLayout_5">
+            <item row="2" column="3">
+             <widget class="QCheckBox" name="checkBox_audio_normalize">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="3">
+             <widget class="QCheckBox" name="checkBox_audio_embed_artwork">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
             <item row="3" column="0">
              <widget class="QLabel" name="label_audio_embed_artwork">
               <property name="text">
@@ -303,10 +336,31 @@
               </property>
              </widget>
             </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_audio_bitrate">
+              <property name="text">
+               <string>Bitrate:</string>
+              </property>
+             </widget>
+            </item>
             <item row="1" column="3">
              <widget class="QComboBox" name="comboBox_audio_bitrate">
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the audio file is reencoded, the selected bitrate will be used.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="label_audio_normalize">
+              <property name="text">
+               <string>Normalize:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label_audio_format">
+              <property name="text">
+               <string>Format:</string>
               </property>
              </widget>
             </item>
@@ -320,41 +374,6 @@
               </property>
               <property name="toolTip">
                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;M4A:&lt;/span&gt; Best quality and speed. Compatible with UltraStar Deluxe, Vocaluxe, Performous and UltraStar World Party.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:700;&quot;&gt;MP3: &lt;/span&gt;Worst quality and speed. Full compatibility.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="0">
-             <widget class="QLabel" name="label_audio_bitrate">
-              <property name="text">
-               <string>Bitrate:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_audio_format">
-              <property name="text">
-               <string>Format:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
-             <widget class="QLabel" name="label_audio_normalize">
-              <property name="text">
-               <string>Normalize:</string>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="3">
-             <widget class="QCheckBox" name="checkBox_audio_normalize">
-              <property name="text">
-               <string/>
-              </property>
-             </widget>
-            </item>
-            <item row="3" column="3">
-             <widget class="QCheckBox" name="checkBox_audio_embed_artwork">
-              <property name="text">
-               <string/>
               </property>
              </widget>
             </item>

--- a/src/usdb_syncer/gui/settings_dialog.py
+++ b/src/usdb_syncer/gui/settings_dialog.py
@@ -119,6 +119,7 @@ class SettingsDialog(Ui_Dialog, QDialog):
             (self.comboBox_fix_linebreaks, settings.FixLinebreaks),
             (self.comboBox_fix_spaces, settings.FixSpaces),
             (self.comboBox_cover_max_size, settings.CoverMaxSize),
+            (self.comboBox_ytdlp_rate_limit, settings.YtdlpRateLimit),
             (self.comboBox_audio_format, settings.AudioFormat),
             (self.comboBox_audio_bitrate, settings.AudioBitrate),
             (self.comboBox_videocontainer, settings.VideoContainer),
@@ -160,6 +161,9 @@ class SettingsDialog(Ui_Dialog, QDialog):
             self.comboBox_fix_spaces.findData(settings.get_fix_spaces())
         )
         self.checkBox_fix_quotation_marks.setChecked(settings.get_fix_quotation_marks())
+        self.comboBox_ytdlp_rate_limit.setCurrentIndex(
+            self.comboBox_ytdlp_rate_limit.findData(settings.get_ytdlp_rate_limit())
+        )
         self.groupBox_audio.setChecked(settings.get_audio())
         self.comboBox_audio_format.setCurrentIndex(
             self.comboBox_audio_format.findData(settings.get_audio_format())
@@ -253,6 +257,7 @@ class SettingsDialog(Ui_Dialog, QDialog):
         )
         settings.set_fix_spaces(self.comboBox_fix_spaces.currentData())
         settings.set_fix_quotation_marks(self.checkBox_fix_quotation_marks.isChecked())
+        settings.set_ytdlp_rate_limit(self.comboBox_ytdlp_rate_limit.currentData())
         settings.set_audio(self.groupBox_audio.isChecked())
         settings.set_audio_format(self.comboBox_audio_format.currentData())
         settings.set_audio_bitrate(self.comboBox_audio_bitrate.currentData())

--- a/src/usdb_syncer/settings.py
+++ b/src/usdb_syncer/settings.py
@@ -76,6 +76,7 @@ class SettingKey(Enum):
     FIX_FIRST_WORDS_CAPITALIZATION = "fixes/firstwordscapitalization"
     FIX_SPACES = "fixes/spaces"
     FIX_QUOTATION_MARKS = "fixes/quotation_marks"
+    YTDLP_RATE_LIMIT = "downloads/ytdlp_rate_limit"
     AUDIO = "downloads/audio"
     AUDIO_FORMAT = "downloads/audio_format"
     AUDIO_BITRATE = "downloads/audio_bitrate"
@@ -216,6 +217,23 @@ class CoverMaxSize(Enum):
                 return "640x640 px"
             case _ as unreachable:
                 assert_never(unreachable)
+
+
+class YtdlpRateLimit(Enum):
+    """Rate limits for yt-dlp (MiB/s)."""
+
+    DISABLE = "disable"
+    KIBS_500 = "500 KiB/s"
+    KIBS_1000 = "1000 KiB/s"
+    KIBS_2000 = "2000 KiB/s"
+    KIBS_3000 = "3000 KiB/s"
+    KIBS_4000 = "4000 KiB/s"
+
+    def __str__(self) -> str:
+        return self.value
+
+    def ytdl_format(self) -> int:
+        return int(int(self.value.removesuffix(" KiB/s")) * 1024)  # in B/s
 
 
 class AudioFormat(Enum):
@@ -594,6 +612,14 @@ def set_setting(key: SettingKey, value: Any) -> None:
         # Qt stores bools as "true" and "false" otherwise
         value = int(value)
     QSettings().setValue(key.value, value)
+
+
+def get_ytdlp_rate_limit() -> YtdlpRateLimit:
+    return get_setting(SettingKey.YTDLP_RATE_LIMIT, YtdlpRateLimit.KIBS_2000)
+
+
+def set_ytdlp_rate_limit(value: YtdlpRateLimit) -> None:
+    set_setting(SettingKey.YTDLP_RATE_LIMIT, value)
 
 
 def get_audio() -> bool:

--- a/src/usdb_syncer/song_txt/tracks.py
+++ b/src/usdb_syncer/song_txt/tracks.py
@@ -387,7 +387,7 @@ class Tracks:
                 note.text, language, opening
             )
             marks_fixed_total = marks_fixed_total + marks_fixed
-        if marks_fixed_total >= 0:
+        if marks_fixed_total > 0:
             logger.debug(
                 f"FIX: {marks_fixed_total} quotation marks in lyrics corrected."
             )


### PR DESCRIPTION
I chose KiB/s as this is what yt-dlp uses in its log messages (and MiB/s). I decided to go for a dropdown field (instead of a spinbox) for ease of use. I am not sure if these are the most sensible options, lower/higher values might be sensible as well.