### PR TITLE
Log local songs that long longer exist on usdb.

### DIFF
--- a/src/usdb_syncer/song_loader.py
+++ b/src/usdb_syncer/song_loader.py
@@ -341,6 +341,10 @@ class _SongLoader(QtCore.QRunnable):
                 self.logger.error("Song has been deleted from USDB.")
                 with db.transaction():
                     self.song.delete()
+                if meta := self.song.sync_meta:
+                    path = meta.path.parent
+                    self.logger.info(f"Trashing local song {path}")
+                    send2trash.send2trash(path)
                 events.SongDeleted(self.song_id).post()
                 events.DownloadFinished(self.song_id).post()
                 return

--- a/src/usdb_syncer/song_routines.py
+++ b/src/usdb_syncer/song_routines.py
@@ -111,13 +111,16 @@ def synchronize_sync_meta_folder(folder: Path) -> None:
                 logger.info(f"Meta file was moved: '{path}'.")
             continue
 
-        if (meta := SyncMeta.try_from_file(path)) and meta.song_id in song_ids:
-            # file was changed and maybe moved
-            to_upsert.append(meta)
-            if meta.sync_meta_id in db_metas:
-                logger.info(f"Updated meta file from disk: '{path}'.")
+        if meta := SyncMeta.try_from_file(path):
+            if meta.song_id in song_ids:
+                # file was changed and maybe moved
+                to_upsert.append(meta)
+                if meta.sync_meta_id in db_metas:
+                    logger.info(f"Updated meta file from disk: '{path}'.")
+                else:
+                    logger.info(f"New meta file found on disk: '{path}'.")
             else:
-                logger.info(f"New meta file found on disk: '{path}'.")
+                logger.info(f"{meta.song_id.usdb_url()} no longer exists: '{path}'.")
 
     SyncMeta.delete_many(tuple(db_metas.keys() - found_metas))
     SyncMeta.upsert_many(to_upsert)


### PR DESCRIPTION
Maybe it makes sense to trash these songs as well (e.g. deleted duplicates), but maybe that should be configurable in the settings.