### PR TITLE
Fix handling of half star ratings.

### DIFF
--- a/src/usdb_syncer/db/__init__.py
+++ b/src/usdb_syncer/db/__init__.py
@@ -246,7 +246,7 @@ class SearchBuilder:
     artists: list[str] = attrs.field(factory=list)
     titles: list[str] = attrs.field(factory=list)
     editions: list[str] = attrs.field(factory=list)
-    ratings: list[int] = attrs.field(factory=list)
+    ratings: list[float] = attrs.field(factory=list)
     statuses: list[DownloadStatus] = attrs.field(factory=list)
     languages: list[str] = attrs.field(factory=list)
     views: list[tuple[int, int | None]] = attrs.field(factory=list)
@@ -303,7 +303,7 @@ class SearchBuilder:
             return f" ORDER BY {sql} {'DESC' if self.descending else 'ASC'}"
         return ""
 
-    def parameters(self) -> Iterator[str | int | bool]:
+    def parameters(self) -> Iterator[str | float | int | bool]:
         if text := _fts5_phrases(self.text):
             yield text
         yield from self.artists
@@ -511,7 +511,7 @@ class UsdbSongParams:
     language: str
     edition: str
     golden_notes: bool
-    rating: int
+    rating: float
     views: int
     sample_url: str
     year: int | None

--- a/src/usdb_syncer/gui/search_tree/item.py
+++ b/src/usdb_syncer/gui/search_tree/item.py
@@ -424,16 +424,20 @@ class RatingVariant(SongMatch, enum.Enum):
     """Selectable variants for the song rating filter."""
 
     R_NONE = None
-    R_1 = 1
-    R_2 = 2
-    R_3 = 3
-    R_4 = 4
-    R_5 = 5
+    R_1_0 = 1
+    R_1_5 = 1.5
+    R_2_0 = 2
+    R_2_5 = 2.5
+    R_3_0 = 3
+    R_3_5 = 3.5
+    R_4_0 = 4
+    R_4_5 = 4.5
+    R_5_0 = 5
 
     def __str__(self) -> str:
         if self == RatingVariant.R_NONE:
             return "None"
-        return self.value * "★"
+        return int(self.value) * "★" + ("½" if self.value % 1 == 0.5 else "")
 
     def build_search(self, search: db.SearchBuilder) -> None:
         search.ratings.append(self.value or 0)

--- a/src/usdb_syncer/gui/song_table/table_model.py
+++ b/src/usdb_syncer/gui/song_table/table_model.py
@@ -217,8 +217,9 @@ def _decoration_data(song: UsdbSong, column: int) -> QIcon | None:
 
 
 @cache
-def rating_str(rating: int) -> str:
-    return rating * "★"
+def rating_str(rating: float) -> str:
+    # Should be Unicode Character 'LEFT HALF BLACK STAR' ⯨ (U+2BE8), using ½ instead
+    return int(rating) * "★" + ("½" if rating % 1 == 0.5 else "")
 
 
 def yes_no_str(yes: bool) -> str:

--- a/src/usdb_syncer/usdb_scraper.py
+++ b/src/usdb_syncer/usdb_scraper.py
@@ -177,7 +177,7 @@ class SongDetails:
     uploader: str
     editors: list[str]
     views: int
-    rating: int
+    rating: float
     votes: int
     audio_sample: str | None
     comments: list[SongComment] = attrs.field(factory=list)
@@ -432,7 +432,8 @@ def _parse_details_table(
         uploader=_find_text_after(details_table, usdb_strings.UPLOADED_BY),
         editors=editors,
         views=int(_find_text_after(details_table, usdb_strings.VIEWS)),
-        rating=sum("star.png" in s.get("src") for s in stars),
+        rating=sum("/star.png" in s.get("src") for s in stars)
+        + 0.5 * sum("/half_star.png" in s.get("src") for s in stars),
         votes=int(votes_str.split("(")[1].split(")")[0]),
         audio_sample=audio_sample or None,
     )

--- a/src/usdb_syncer/usdb_song.py
+++ b/src/usdb_syncer/usdb_song.py
@@ -26,7 +26,7 @@ class UsdbSong:
     creator: str
     edition: str
     golden_notes: bool
-    rating: int
+    rating: float
     views: int
     sample_url: str
     # not in USDB song list
@@ -69,7 +69,8 @@ class UsdbSong:
             creator=creator,
             edition=edition,
             golden_notes=golden_notes == strings.YES,
-            rating=rating.count("star.png"),
+            rating=rating.count("images/star.png")
+            + 0.5 * rating.count("images/half_star.png"),
             views=int(views),
             sample_url=sample_url,
         )


### PR DESCRIPTION
Unfortunately, LEFT HALF BLACK STAR is not yet widely available, so ½ is used as a fallback symbol for half star ratings.

Fixes #325.