### PR TITLE
Fix image processing

### DIFF
--- a/src/usdb_syncer/resource_dl.py
+++ b/src/usdb_syncer/resource_dl.py
@@ -1,5 +1,6 @@
 """Functions for downloading and processing media."""
 
+import io
 import os
 from enum import Enum
 from pathlib import Path
@@ -215,8 +216,8 @@ def download_and_process_image(
         return None
 
     path = target_stem.with_name(f"{target_stem.name} [{kind.value}].jpg")
-    with path.open("wb") as file:
-        file.write(img_bytes)
+    with Image.open(io.BytesIO(img_bytes)).convert("RGB") as img:
+        img.save(path)
 
     if process:
         _process_image(meta_tags, max_width, path)

--- a/src/usdb_syncer/settings.py
+++ b/src/usdb_syncer/settings.py
@@ -394,7 +394,7 @@ class Browser(Enum):
             return rookiepy.to_cookiejar(function([Usdb.DOMAIN]))
         except Exception:  # pylint: disable=broad-exception-caught
             logger.debug(traceback.format_exc())
-        logger.warning(f"Failed to retrieve {str(self).capitalize()} cookies.")
+        logger.warning(f"Failed to retrieve {str(self)} cookies.")
         return None
 
 


### PR DESCRIPTION
This fixes multiple issues:
- non-jpg image formats (png, webp) were erroneously saved with .jpg extension, which turned out to be a problem with MelodyMania.
- different order of operations for crop and resize (cover: first crop, then resize - background: first resize, then crop) is now in place
- image files with CMYK color channels are now correctly converted to RGB color channels before saving (which was only an issue if no post-processing took place, which always triggered the RGB conversion)