### PR TITLE
Ensure games are launched in detached process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - The check for existing / outdated local resources has been improved to account for different precisions of modified times for different file systems.
 - Provide binaries for Intel-based MacOS systems.
 - YouTube logged-in cookies are now used for age-restricted resources.
+- Games started from within the Syncer are properly cleaned up, fixing subsequent starts.
 
 ## Features
 

--- a/src/usdb_syncer/settings.py
+++ b/src/usdb_syncer/settings.py
@@ -608,9 +608,7 @@ class SupportedApps(StrEnum):
         else:
             cmd = [str(executable), self.songpath_parameter(), str(path)]
         try:
-            # We are not using a context manager here so that the app is launched
-            # without blocking the syncer.
-            subprocess.Popen(cmd)  # pylint: disable=consider-using-with
+            utils.start_process_detached(cmd)
         except FileNotFoundError:
             logger.error(
                 f"Failed to launch {self} from '{str(executable)}', file not found. "

--- a/src/usdb_syncer/utils.py
+++ b/src/usdb_syncer/utils.py
@@ -267,3 +267,14 @@ def newer_version_available() -> str | None:
 
     logger.info("Could not determine the latest version.")
     return None
+
+
+def start_process_detached(command: list[str]) -> subprocess.Popen:
+    """Start a process in a fully detached mode, cross-platform."""
+    # We are not using a context manager here so that the app is launched
+    # without blocking the syncer.
+    flags = 0
+    if sys.platform == "win32":
+        flags = subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_PROCESS_GROUP
+    # pylint: disable=consider-using-with
+    return subprocess.Popen(command, creationflags=flags, close_fds=True)


### PR DESCRIPTION
When USDX or Vocaluxe were launched via the Syncer, the process was not properly cleaned up, and subsequent starts would fail.