### PR TITLE
Handle unavailable format gracefully.

### DIFF
--- a/src/usdb_syncer/constants.py
+++ b/src/usdb_syncer/constants.py
@@ -115,6 +115,7 @@ class YtErrorMsg:
     YT_UNAVAILABLE = "Video unavailable"
     YT_PARSE_ERROR = "Failed to parse XML"
     YT_FORBIDDEN = "HTTP Error 403: Forbidden"
+    YT_FORMAT_NOT_AVAILABLE = "Requested format is not available."
 
 
 SUPPORTED_VIDEO_SOURCES_REGEX = re.compile(


### PR DESCRIPTION
Less common sites may offer limited audio/video formats, so the requested format might not be available. We can fallback to whatever best format is available. At least ffmpeg-based Karaoke softwares should be able to handle the resulting file (fixes e.g. https://usdb.animux.de/index.php?link=detail&id=14856).