### PR TITLE
Fix db expression tree

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -22,4 +22,4 @@ jobs:
       - name: Install tox and poetry
         run: python -m pip install tox poetry
       - name: Test with tox
-        run: tox
+        run: tox -- --runslow

--- a/src/usdb_syncer/db/__init__.py
+++ b/src/usdb_syncer/db/__init__.py
@@ -820,7 +820,10 @@ class ResourceFileParams:
 
 
 def delete_resource_files(ids: Iterable[tuple[SyncMetaId, ResourceFileKind]]) -> None:
-    for batch in batched(ids, _SQL_VARIABLES_LIMIT // 2):
+    for batch in batched(ids, 980):  # 998 is the maximum batch size we can use. Since
+        # an sqlite update could change this without us
+        # noticing quickly, we're leaving some space.
+        # Performance impact is negligible.
         if not batch:
             continue
         conditions = " OR ".join("(sync_meta_id = ? AND kind = ?)" for _ in batch)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,39 @@ import datetime
 from pathlib import Path
 
 import pytest
+from _pytest.config import Config
+from _pytest.config.argparsing import Parser
+from _pytest.nodes import Item
 
 from usdb_syncer import SongId, SyncMetaId
 from usdb_syncer.meta_tags import ImageMetaTags, MetaTags
 from usdb_syncer.sync_meta import ResourceFile, SyncMeta
 from usdb_syncer.usdb_scraper import SongDetails
 from usdb_syncer.usdb_song import UsdbSong
+
+
+# taken from https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+def pytest_addoption(parser: Parser) -> None:
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config: Config) -> None:
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config: Config, items: list[Item]) -> None:
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
+
+#
 
 
 @pytest.fixture(scope="session", name="resource_dir")

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -3,9 +3,12 @@
 from pathlib import Path
 
 import attrs
+import pytest
 
-from usdb_syncer import db
+from usdb_syncer import SongId, SyncMetaId, db
 from usdb_syncer.usdb_song import UsdbSong
+
+PERFORMANCE_TEST_ITEM_COUNT = 100000
 
 
 def test_persisting_usdb_song(song: UsdbSong) -> None:
@@ -20,8 +23,8 @@ def test_persisting_usdb_song(song: UsdbSong) -> None:
 
 def test_persisting_saved_search() -> None:
     search = db.SavedSearch(
-        "name",
-        db.SearchBuilder(
+        name="name",
+        search=db.SearchBuilder(
             order=db.SongOrder.ARTIST,
             text="foo bar",
             genres=["Rock", "Pop"],
@@ -43,3 +46,57 @@ def test_persisting_saved_search() -> None:
         search.update(new_name="name")
         assert search.name == "name (1)"
         assert len(list(db.SavedSearch.load_saved_searches())) == 2
+
+
+@pytest.mark.slow
+def test_upsert_delete_sync_metas_many() -> None:
+    """Test inserting and deleting many sync metas at once."""
+    sync_meta_ids = [SyncMetaId.new() for _ in range(PERFORMANCE_TEST_ITEM_COUNT)]
+    sync_meta_params = [
+        db.SyncMetaParams(
+            sync_meta_id=sync_meta_id,
+            path=str(sync_meta_id),
+            song_id=SongId(0),
+            mtime=0,
+            meta_tags="",
+            pinned=False,
+        )
+        for sync_meta_id in sync_meta_ids
+    ]
+    with db.managed_connection(":memory:"):
+        db.upsert_sync_metas(sync_meta_params)
+        db.delete_sync_metas(tuple(sync_meta_ids))
+
+
+@pytest.mark.slow
+def test_upsert_delete_resource_files_many() -> None:
+    """Test inserting and deleting many resource files at once."""
+    sync_meta_ids = [SyncMetaId.new() for _ in range(PERFORMANCE_TEST_ITEM_COUNT)]
+    resource_file_params = [
+        db.ResourceFileParams(
+            sync_meta_id=sync_meta_id,
+            kind=db.ResourceFileKind.AUDIO,
+            fname=str(sync_meta_id),
+            mtime=0,
+            resource="",
+        )
+        for sync_meta_id in sync_meta_ids
+    ]
+    with db.managed_connection(":memory:"):
+        db.upsert_resource_files(resource_file_params)
+        db.delete_resource_files(
+            (sync_meta_id, db.ResourceFileKind.AUDIO) for sync_meta_id in sync_meta_ids
+        )
+
+
+@pytest.mark.slow
+def test_upsert_delete_custom_metadata_many() -> None:
+    """Test inserting and deleting many custom metadata at once."""
+    sync_meta_ids = [SyncMetaId.new() for _ in range(PERFORMANCE_TEST_ITEM_COUNT)]
+    custom_metadata_params = [
+        db.CustomMetaDataParams(sync_meta_id=sync_meta_id, key="", value="")
+        for sync_meta_id in sync_meta_ids
+    ]
+    with db.managed_connection(":memory:"):
+        db.upsert_custom_meta_data(custom_metadata_params)
+        db.delete_custom_meta_data(sync_meta_ids)


### PR DESCRIPTION
Fixes #406. I also added some tests to ensure that this error is caught in the future.

Finally, I added an option for pytest to mark tests as slow, which requires an additional cli argument. It isn't run by default locally because test failures should be rare, but the GH Actions pipeline, does also test those.