### PR TITLE
Concentrate and improve networking

### DIFF
--- a/src/tools/generate_song_list_json.py
+++ b/src/tools/generate_song_list_json.py
@@ -4,18 +4,16 @@ import argparse
 import sys
 from pathlib import Path
 
-from requests import Session
-
 from usdb_syncer import SongId, song_routines
-from usdb_syncer.usdb_scraper import get_usdb_available_songs, login_to_usdb
+from usdb_syncer.net import UsdbSessionManager
 
 
 def main(target: Path, user: str, password: str) -> None:
-    session = Session()
-    if not login_to_usdb(session, user, password):
+    session = UsdbSessionManager.session()
+    if not session.establish_login((user, password)):
         print("Invalid credentials!")
         sys.exit(1)
-    songs = get_usdb_available_songs(SongId(0), session=session)
+    songs = session.get_usdb_available_songs(SongId(0))
     song_routines.dump_available_songs(songs, target)
     print(f"{len(songs)} entries written to {target}.")
 

--- a/src/usdb_syncer/gui/comment_dialog.py
+++ b/src/usdb_syncer/gui/comment_dialog.py
@@ -3,7 +3,7 @@
 from PySide6.QtWidgets import QDialog, QWidget
 
 from usdb_syncer.gui.forms.CommentDialog import Ui_Dialog
-from usdb_syncer.usdb_scraper import post_song_comment
+from usdb_syncer.net import UsdbSessionManager
 from usdb_syncer.usdb_song import UsdbSong
 
 
@@ -23,5 +23,6 @@ class CommentDialog(Ui_Dialog, QDialog):
         song_id = self._selected_song.song_id
         text = self.text_edit_comment.toPlainText()
         rating = self.combobox_rating.currentData()
-        post_song_comment(song_id, text, rating)
+        session = UsdbSessionManager.session()
+        session.post_song_comment(song_id, text, rating)
         super().accept()

--- a/src/usdb_syncer/gui/mw.py
+++ b/src/usdb_syncer/gui/mw.py
@@ -24,9 +24,9 @@ from usdb_syncer.gui.settings_dialog import SettingsDialog
 from usdb_syncer.gui.song_table.song_table import SongTable
 from usdb_syncer.gui.usdb_login_dialog import UsdbLoginDialog
 from usdb_syncer.logger import logger
+from usdb_syncer.net import UsdbSessionManager
 from usdb_syncer.song_loader import DownloadManager
 from usdb_syncer.sync_meta import SyncMeta
-from usdb_syncer.usdb_scraper import post_song_rating
 from usdb_syncer.usdb_song import UsdbSong
 from usdb_syncer.utils import AppPaths, LinuxEnvCleaner, open_path_or_file
 
@@ -305,7 +305,8 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def _rate_in_usdb(self, stars: int) -> None:
         song = self.table.current_song()
         if song:
-            post_song_rating(song.song_id, stars)
+            session = UsdbSessionManager.session()
+            session.post_song_rating(song.song_id, stars)
         else:
             logger.debug("Not rating song: no song selected.")
 

--- a/src/usdb_syncer/gui/settings_dialog.py
+++ b/src/usdb_syncer/gui/settings_dialog.py
@@ -10,8 +10,8 @@ from PySide6.QtWidgets import QDialog, QDialogButtonBox, QFileDialog, QWidget
 from usdb_syncer import SongId, path_template, settings
 from usdb_syncer.gui import icons, theme
 from usdb_syncer.gui.forms.SettingsDialog import Ui_Dialog
+from usdb_syncer.net import UsdbSessionManager
 from usdb_syncer.path_template import PathTemplate
-from usdb_syncer.usdb_scraper import SessionManager
 from usdb_syncer.usdb_song import UsdbSong
 
 _FALLBACK_SONG = UsdbSong(
@@ -274,13 +274,17 @@ class SettingsDialog(Ui_Dialog, QDialog):
     def apply(self) -> None:
         self._save_settings()
         if self._browser != self.comboBox_browser.currentData():
-            SessionManager.reset_session()
+            UsdbSessionManager.session().set_cookies(
+                self.comboBox_browser.currentData()
+            )
 
     def accept(self) -> None:
         if not self._save_settings():
             return
         if self._browser != self.comboBox_browser.currentData():
-            SessionManager.reset_session()
+            UsdbSessionManager.session().set_cookies(
+                self.comboBox_browser.currentData()
+            )
         super().accept()
 
     def _save_settings(self) -> bool:

--- a/src/usdb_syncer/net.py
+++ b/src/usdb_syncer/net.py
@@ -1,0 +1,267 @@
+import abc
+import time
+import urllib
+import urllib.parse
+from typing import Tuple, override
+
+from bs4 import BeautifulSoup
+from requests import Response, Session
+
+from usdb_syncer import SongId, constants, settings, usdb_scraper, usdb_song, utils
+
+GLOBAL_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36"
+    )
+}
+
+
+class SyncerSession(abc.ABC):
+    """Base session class."""
+
+    BASE_URL: str
+    session: Session
+    timeout: int
+
+    @abc.abstractmethod
+    def __init__(self, base_url: str, **kwargs: dict) -> None:
+        self.BASE_URL = base_url
+        self.session = Session(**kwargs)
+        self.session.verify = True
+        self.set_headers(GLOBAL_HEADERS)
+        self.timeout = 10
+
+    @abc.abstractmethod
+    def conn_failed(self, response: Response) -> None:
+        raise NotImplementedError
+
+    def handle_response(self, response: Response) -> str:
+        return response.text
+
+    def set_cookies(self, browser: settings.Browser) -> None:
+        """Set cookies for the session. Clears existing cookies."""
+        self.session.cookies.clear()
+        if jar := browser.cookies():
+            for cookie in jar:
+                self.session.cookies.set_cookie(cookie)
+
+    def set_headers(self, headers: dict) -> None:
+        """Set headers for the session. Does not clear existing headers."""
+        self.session.headers.update(headers)
+
+    def _request(
+        self,
+        method: str,
+        rel_url: str,
+        data: dict,
+        headers: dict,
+        params: dict,
+    ) -> str:
+        """Make a request. Calls conn_failed on error."""
+        complete_url = urllib.parse.urljoin(self.BASE_URL, rel_url)
+        response = self.session.request(
+            method=method,
+            url=complete_url,
+            data=data,
+            headers=headers,
+            params=params,
+            timeout=self.timeout,
+        )
+        if not response.ok:
+            self.conn_failed(response)
+        response.encoding = "utf-8"
+        return self.handle_response(response)
+
+    def get(self, rel_url: str, params: dict, headers: dict) -> str:
+        """Make a GET request."""
+        return self._request("GET", rel_url, headers=headers, params=params, data={})
+
+    def post(self, rel_url: str, data: dict, params: dict, headers: dict) -> str:
+        """Make a POST request."""
+        return self._request("POST", rel_url, data=data, headers=headers, params=params)
+
+    def close(self) -> None:
+        """Close the session."""
+        self.session.close()
+
+
+class UsdbSession(SyncerSession):
+    """Session class for USDB."""
+
+    logged_in: bool = False
+    username: str | None = None
+
+    @override
+    def __init__(self, **kwargs: dict) -> None:
+        super().__init__(base_url=constants.Usdb.BASE_URL, **kwargs)
+
+    @override
+    def conn_failed(self, response: Response) -> None:
+        """Handle connection failure."""
+        self.logged_in = False
+
+    @override
+    def handle_response(self, response: Response) -> str:
+        """Handle response."""
+        page = utils.normalize(response.text)
+        # TODO handle errors
+        return page
+
+    @override
+    def close(self) -> None:
+        super().close()
+        self.logged_in = False
+        self.username = None
+
+    def establish_login(self, *auth: Tuple[str, str]) -> bool:
+        text = self.get("", params={"link": "profil"}, headers={})
+        if username := usdb_scraper.username_from_html(text):
+            self.username = username
+            self.logged_in = True
+            return True
+
+        if not auth:
+            username, password = settings.get_usdb_auth()
+        else:
+            username, password = auth[0]
+        if not username or not password:
+            return False
+        text = self.post(
+            "",
+            data={"user": username, "pass": password, "login": "Login"},
+            params={},
+            headers={},
+        )
+        if constants.UsdbStrings.LOGIN_INVALID not in text:
+            self.username = username
+            self.logged_in = True
+            return True
+        self.username = None
+        self.logged_in = False
+        return False
+
+    def logout(self) -> None:
+        self.post("", params={"link": "logout"}, data={}, headers={})
+        self.logged_in = False
+        self.username = None
+
+    def get_song_details(self, song_id: SongId) -> usdb_scraper.SongDetails:
+        text = self.get(
+            "index.php", params={"id": str(int(song_id)), "link": "detail"}, headers={}
+        )
+        return usdb_scraper.parse_song_page(
+            BeautifulSoup(utils.normalize(text), "lxml"), song_id
+        )
+
+    def get_usdb_available_songs(
+        self, max_skip_id: SongId, content_filter: dict[str, str] | None = None
+    ) -> list[usdb_song.UsdbSong]:
+        """Return a list of all available songs.
+
+        Parameters:
+            max_skip_id: only fetch ids larger than this
+            content_filter: filters response (e.g. {'artist': 'The Beatles'})
+        """
+        available_songs: list[usdb_song.UsdbSong] = []
+        payload = {
+            "order": "id",
+            "ud": "desc",
+            "limit": str(constants.Usdb.MAX_SONGS_PER_PAGE),
+            "details": "1",
+        }
+
+        payload.update(content_filter or {})
+        for start in range(
+            0, constants.Usdb.MAX_SONG_ID, constants.Usdb.MAX_SONGS_PER_PAGE
+        ):
+            payload["start"] = str(start)
+            html = self.post(
+                "index.php", params={"link": "list"}, data=payload, headers={}
+            )
+            songs = [
+                song
+                for song in usdb_scraper.parse_songs_from_songlist(html)
+                if song.song_id > max_skip_id
+            ]
+            available_songs.extend(songs)
+
+            if len(songs) < constants.Usdb.MAX_SONGS_PER_PAGE:
+                break
+        return available_songs
+
+    def get_notes(self, song_id: SongId) -> str:
+        """Get notes for a song."""
+        html = self.post(
+            "index.php",
+            params={"link": "gettxt", "id": str(int(song_id))},
+            data={"wd": "1"},
+            headers={},
+        )
+        return usdb_scraper.parse_song_txt_from_txt_page(BeautifulSoup(html, "lxml"))
+
+    def post_song_comment(self, song_id: SongId, text: str, rating: str) -> None:
+        """Post a comment to a song."""
+        data = {"text": text, "stars": rating}
+        self.post(
+            "index.php",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            params={"link": "detail", "id": str(int(song_id)), "comment": str(1)},
+            data=data,
+        )
+
+    def post_song_rating(self, song_id: SongId, stars: int) -> None:
+        """Post a rating to a song."""
+        data = {"stars": str(stars), "text": "onlyvoting"}
+        self.post(
+            "index.php",
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            params={"link": "detail", "id": str(int(song_id)), "rating": str(1)},
+            data=data,
+        )
+
+
+class UsdbSessionManager:
+    _session: UsdbSession | None = None
+    _connecting: bool = False
+
+    @classmethod
+    def session(cls) -> UsdbSession:
+        while cls._connecting:
+            time.sleep(0.1)
+        if cls._session is None:
+            cls._connecting = True
+            try:
+                cls._session = UsdbSession()
+                cls._session.set_cookies(settings.get_browser())
+                cls._session.establish_login()
+            finally:
+                cls._connecting = False
+        return cls._session
+
+    @classmethod
+    def reset_session(cls) -> None:
+        if cls._session:
+            cls._session.close()
+            cls._session = None
+
+    @classmethod
+    def has_session(cls) -> bool:
+        return cls._session is not None
+
+
+class GenericSession(SyncerSession):
+    """Generic session class for other sites."""
+
+    @override
+    def __init__(self, base_url: str) -> None:
+        super().__init__(base_url=base_url)
+
+    @override
+    def conn_failed(self, response: Response) -> None:
+        """Handle connection failure."""
+        return None
+
+
+def get_generic_session(base_url: str) -> SyncerSession:
+    return GenericSession(base_url)

--- a/src/usdb_syncer/song_loader.py
+++ b/src/usdb_syncer/song_loader.py
@@ -25,9 +25,9 @@ from usdb_syncer import (
     errors,
     events,
     hooks,
+    net,
     resource_dl,
     settings,
-    usdb_scraper,
     utils,
 )
 from usdb_syncer.custom_data import CustomData
@@ -286,9 +286,10 @@ class _Context:
 def _get_usdb_data(
     song_id: SongId, txt_options: download_options.TxtOptions | None, log: Logger
 ) -> tuple[SongDetails, SongTxt]:
-    details = usdb_scraper.get_usdb_details(song_id)
+    session = net.UsdbSessionManager.session()
+    details = session.get_song_details(song_id)
     log.info(f"Found '{details.artist} - {details.title}' on USDB.")
-    txt_str = usdb_scraper.get_notes(details.song_id, log)
+    txt_str = session.get_notes(song_id)
     txt = SongTxt.parse(txt_str, log)
     txt.sanitize(txt_options)
     txt.headers.creator = txt.headers.creator or details.uploader or None

--- a/tests/unit/test_usdb_scraper.py
+++ b/tests/unit/test_usdb_scraper.py
@@ -7,9 +7,9 @@ from bs4 import BeautifulSoup
 
 from usdb_syncer import SongId
 from usdb_syncer.usdb_scraper import (
-    _parse_song_page,
-    _parse_song_txt_from_txt_page,
-    _parse_songs_from_songlist,
+    parse_song_page,
+    parse_song_txt_from_txt_page,
+    parse_songs_from_songlist,
 )
 
 
@@ -22,7 +22,7 @@ def get_soup(resource_dir: Path, resource: str) -> BeautifulSoup:
 
 def test__parse_song_txt_from_txt_page(resource_dir: Path) -> None:
     soup = get_soup(resource_dir, "txt_page.htm")
-    txt = _parse_song_txt_from_txt_page(soup)
+    txt = parse_song_txt_from_txt_page(soup)
     assert txt is not None
     assert txt.startswith("#ARTIST:")
     assert txt.endswith("\nE")
@@ -31,7 +31,7 @@ def test__parse_song_txt_from_txt_page(resource_dir: Path) -> None:
 def test__parse_song_page_with_commented_embedded_video(resource_dir: Path) -> None:
     song_id = SongId(26152)
     soup = get_soup(resource_dir, "song_page_with_embedded_video.htm")
-    details = _parse_song_page(soup, song_id)
+    details = parse_song_page(soup, song_id)
     assert details.song_id == song_id
     assert details.artist == "Revolverheld"
     assert details.title == "Ich lass für dich das Licht an"
@@ -65,7 +65,7 @@ def test__parse_song_page_with_commented_embedded_video(resource_dir: Path) -> N
 def test__parse_song_page_with_commented_unembedded_video(resource_dir: Path) -> None:
     song_id = SongId(16575)
     soup = get_soup(resource_dir, "song_page_with_unembedded_video.htm")
-    details = _parse_song_page(soup, song_id)
+    details = parse_song_page(soup, song_id)
     assert len(details.comments) == 1
     assert details.comments[0].contents.youtube_ids == ["WIAvMiUcCgw"]
 
@@ -73,7 +73,7 @@ def test__parse_song_page_with_commented_unembedded_video(resource_dir: Path) ->
 def test__parse_song_page_without_comments_or_cover(resource_dir: Path) -> None:
     song_id = SongId(26244)
     soup = get_soup(resource_dir, "song_page_without_comments_or_cover.htm")
-    details = _parse_song_page(soup, song_id)
+    details = parse_song_page(soup, song_id)
     assert details.song_id == song_id
     assert details.artist == "The Used"
     assert details.title == "River Stay"
@@ -95,10 +95,8 @@ def test__parse_song_page_without_comments_or_cover(resource_dir: Path) -> None:
 
 
 def test_parse_song_list(resource_dir: Path) -> None:
-    html = (resource_dir / "html" / "usdb-animux-de" / "song_list.htm").read_text(
-        encoding="utf8"
-    )
-    songs = list(_parse_songs_from_songlist(html))
+    html = (resource_dir / "html" / "song_list.htm").read_text(encoding="utf8")
+    songs = list(parse_songs_from_songlist(html))
     assert len(songs) == 3
     # first song: no audio sample, but cover image
     assert songs[0].sample_url == ""


### PR DESCRIPTION
In reference to my comment [here](https://github.com/bohning/usdb_syncer/pull/415#issuecomment-2871683317), and in general too, I reworked much of the actual networking aspects of `usdb_scraper.py`. The new interface(s) in `net.py` allow for unifying error handling and retries.

I intend to rewire all other networking calls to this new module, so that the only place `requests` is imported is here.

This is unfinished, but I'm opening the PR for feedback. Remaining work includes:
- [ ] Using `net.py` for all other requests
- [ ] Sending events in specific instances (#415)
- [ ] Add (or sometimes re-add) debug logging
- [ ] Add error handling when a request fails
- [ ] (potentially) add (configurable?) retries for when a request fails
- [ ] Maybe remove `logged_in` attribute of `UsdbSession` and just use username