### PR TITLE
Shortcuts

### DIFF
--- a/src/usdb_syncer/events.py
+++ b/src/usdb_syncer/events.py
@@ -104,3 +104,11 @@ class SongDirChanged(SubscriptableEvent):
     """Sent when the selected song directory has changed."""
 
     new_dir: Path
+
+
+# other
+
+
+@attrs.define(slots=False)
+class PreferencesChanged(SubscriptableEvent):
+    """Sent when the preferences potentially changed."""

--- a/src/usdb_syncer/gui/debug_console.py
+++ b/src/usdb_syncer/gui/debug_console.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import QDialog, QWidget
 
 from usdb_syncer.gui import gui_utils
 from usdb_syncer.gui.forms.DebugConsole import Ui_Dialog
+from usdb_syncer.gui.shortcuts import DebugConsoleShortcut
 
 
 class DebugConsole(Ui_Dialog, QDialog):
@@ -26,10 +27,10 @@ class DebugConsole(Ui_Dialog, QDialog):
         self.output.setFont(font)
 
     def _set_shortcuts(self) -> None:
-        gui_utils.set_shortcut("Ctrl+Return", self, self._execute)
-        gui_utils.set_shortcut("Ctrl+Shift+Return", self, self._execute_and_print)
-        gui_utils.set_shortcut("Ctrl+L", self, self.output.clear)
-        gui_utils.set_shortcut("Ctrl+Shift+L", self, self.input.clear)
+        DebugConsoleShortcut.EXECUTE.connect(self, self._execute)
+        DebugConsoleShortcut.EXECUTE_PRINT.connect(self, self._execute_and_print)
+        DebugConsoleShortcut.CLEAR_OUTPUT.connect(self, self.output.clear)
+        DebugConsoleShortcut.CLEAR_INPUT.connect(self, self.input.clear)
 
     def _execute_and_print(self) -> None:
         cursor = self.input.textCursor()

--- a/src/usdb_syncer/gui/forms/MainWindow.ui
+++ b/src/usdb_syncer/gui/forms/MainWindow.ui
@@ -249,12 +249,14 @@
     </widget>
     <widget class="QMenu" name="menu_open_song_in">
      <property name="title">
-      <string>Open &amp;Song in</string>
+      <string>&amp;Open Song in</string>
      </property>
      <property name="icon">
       <iconset resource="../resources/qt/resources.qrc">
        <normaloff>:/icons/music--arrow.png</normaloff>:/icons/music--arrow.png</iconset>
      </property>
+     <addaction name="action_open_song_folder"/>
+     <addaction name="separator"/>
      <addaction name="action_open_song_in_usdx"/>
      <addaction name="action_open_song_in_vocaluxe"/>
      <addaction name="action_open_song_in_performous"/>
@@ -283,7 +285,6 @@
     <addaction name="action_post_comment_in_usdb"/>
     <addaction name="menu_rate_song_on_usdb"/>
     <addaction name="separator"/>
-    <addaction name="action_open_song_folder"/>
     <addaction name="menu_open_song_in"/>
     <addaction name="menu_custom_data"/>
     <addaction name="action_pin"/>
@@ -627,7 +628,7 @@
      <normaloff>:/icons/folder_note.png</normaloff>:/icons/folder_note.png</iconset>
    </property>
    <property name="text">
-    <string>&amp;Open Song Folder</string>
+    <string>File &amp;Explorer</string>
    </property>
   </action>
   <action name="action_delete">

--- a/src/usdb_syncer/gui/forms/MainWindow.ui
+++ b/src/usdb_syncer/gui/forms/MainWindow.ui
@@ -314,6 +314,7 @@
     <addaction name="action_go_to_search"/>
     <addaction name="action_go_to_song_table"/>
     <addaction name="action_go_to_filters"/>
+    <addaction name="action_go_to_filter_search"/>
    </widget>
    <addaction name="menu_view"/>
    <addaction name="menu_songs"/>
@@ -837,6 +838,11 @@
   <action name="action_go_to_filters">
    <property name="text">
     <string>Go to Filters</string>
+   </property>
+  </action>
+  <action name="action_go_to_filter_search">
+   <property name="text">
+    <string>Go to Filter Search</string>
    </property>
   </action>
  </widget>

--- a/src/usdb_syncer/gui/forms/MainWindow.ui
+++ b/src/usdb_syncer/gui/forms/MainWindow.ui
@@ -315,6 +315,7 @@
     <addaction name="action_go_to_song_table"/>
     <addaction name="action_go_to_filters"/>
     <addaction name="action_go_to_filter_search"/>
+    <addaction name="action_go_to_open_song_menu"/>
    </widget>
    <addaction name="menu_view"/>
    <addaction name="menu_songs"/>
@@ -843,6 +844,11 @@
   <action name="action_go_to_filter_search">
    <property name="text">
     <string>Go to F&amp;ilter Search</string>
+   </property>
+  </action>
+  <action name="action_go_to_open_song_menu">
+   <property name="text">
+    <string>Go to &amp;Open Song Menu</string>
    </property>
   </action>
  </widget>

--- a/src/usdb_syncer/gui/forms/MainWindow.ui
+++ b/src/usdb_syncer/gui/forms/MainWindow.ui
@@ -202,7 +202,7 @@
    </property>
    <widget class="QMenu" name="menu_tools">
     <property name="title">
-     <string>Tools</string>
+     <string>&amp;Tools</string>
     </property>
     <property name="toolTipsVisible">
      <bool>true</bool>
@@ -213,7 +213,7 @@
    </widget>
    <widget class="QMenu" name="menu_usdb">
     <property name="title">
-     <string>USDB</string>
+     <string>&amp;USDB</string>
     </property>
     <property name="toolTipsVisible">
      <bool>true</bool>
@@ -223,7 +223,7 @@
    </widget>
    <widget class="QMenu" name="menu_about">
     <property name="title">
-     <string>Help</string>
+     <string>&amp;Help</string>
     </property>
     <property name="toolTipsVisible">
      <bool>true</bool>
@@ -233,14 +233,14 @@
    </widget>
    <widget class="QMenu" name="menu_songs">
     <property name="title">
-     <string>Songs</string>
+     <string>&amp;Songs</string>
     </property>
     <property name="toolTipsVisible">
      <bool>true</bool>
     </property>
     <widget class="QMenu" name="menu_custom_data">
      <property name="title">
-      <string>Custom Data</string>
+      <string>Custo&amp;m Data</string>
      </property>
      <property name="icon">
       <iconset resource="../resources/qt/resources.qrc">
@@ -249,7 +249,7 @@
     </widget>
     <widget class="QMenu" name="menu_open_song_in">
      <property name="title">
-      <string>Open Song in</string>
+      <string>Open &amp;Song in</string>
      </property>
      <property name="icon">
       <iconset resource="../resources/qt/resources.qrc">
@@ -265,7 +265,7 @@
     </widget>
     <widget class="QMenu" name="menu_rate_song_on_usdb">
      <property name="title">
-      <string>Rate Song on USDB</string>
+      <string>&amp;Rate Song on USDB</string>
      </property>
      <property name="icon">
       <iconset resource="../resources/qt/resources.qrc">
@@ -293,7 +293,7 @@
    </widget>
    <widget class="QMenu" name="menu_local">
     <property name="title">
-     <string>Local</string>
+     <string>&amp;Local</string>
     </property>
     <property name="toolTipsVisible">
      <bool>true</bool>
@@ -304,12 +304,12 @@
    </widget>
    <widget class="QMenu" name="menu_view">
     <property name="title">
-     <string>View</string>
+     <string>&amp;View</string>
     </property>
    </widget>
    <widget class="QMenu" name="menuGo">
     <property name="title">
-     <string>Go</string>
+     <string>&amp;Go</string>
     </property>
     <addaction name="action_go_to_search"/>
     <addaction name="action_go_to_song_table"/>
@@ -497,7 +497,7 @@
      <normaloff>:/icons/tag-hash.png</normaloff>:/icons/tag-hash.png</iconset>
    </property>
    <property name="text">
-    <string>Create Meta Tags</string>
+    <string>Create &amp;Meta Tags</string>
    </property>
   </action>
   <action name="action_settings">
@@ -506,7 +506,7 @@
      <normaloff>:/icons/cog.png</normaloff>:/icons/cog.png</iconset>
    </property>
    <property name="text">
-    <string>Settings</string>
+    <string>&amp;Settings</string>
    </property>
   </action>
   <action name="action_generate_song_list">
@@ -515,7 +515,7 @@
      <normaloff>:/icons/report.png</normaloff>:/icons/report.png</iconset>
    </property>
    <property name="text">
-    <string>Create Report</string>
+    <string>Create &amp;Report</string>
    </property>
   </action>
   <action name="action_refetch_song_list">
@@ -524,7 +524,7 @@
      <normaloff>:/icons/check_for_update.png</normaloff>:/icons/check_for_update.png</iconset>
    </property>
    <property name="text">
-    <string>Check USDB Song List</string>
+    <string>Check USDB &amp;Song List</string>
    </property>
    <property name="toolTip">
     <string>Redownload the entire song list from USDB</string>
@@ -536,7 +536,7 @@
      <normaloff>:/icons/database.png</normaloff>:/icons/database.png</iconset>
    </property>
    <property name="text">
-    <string>Find Local Songs</string>
+    <string>Find &amp;Local Songs</string>
    </property>
    <property name="toolTip">
     <string>Select songs matching a txt file in the given folder</string>
@@ -548,7 +548,7 @@
      <normaloff>:/icons/log.png</normaloff>:/icons/log.png</iconset>
    </property>
    <property name="text">
-    <string>Show Log</string>
+    <string>Show &amp;Log</string>
    </property>
   </action>
   <action name="action_import_usdb_ids">
@@ -557,7 +557,7 @@
      <normaloff>:/icons/document-export.png</normaloff>:/icons/document-export.png</iconset>
    </property>
    <property name="text">
-    <string>Select Songs from Files</string>
+    <string>Select Songs from &amp;Files</string>
    </property>
    <property name="toolTip">
     <string>Read song IDs from selected files and select the corresponding songs in the song table</string>
@@ -569,7 +569,7 @@
      <normaloff>:/icons/document-import.png</normaloff>:/icons/document-import.png</iconset>
    </property>
    <property name="text">
-    <string>Export selected IDs to File</string>
+    <string>&amp;Export selected IDs to File</string>
    </property>
    <property name="toolTip">
     <string>Write the IDs of the selected songs to a file</string>
@@ -581,7 +581,7 @@
      <normaloff>:/icons/status.png</normaloff>:/icons/status.png</iconset>
    </property>
    <property name="text">
-    <string>Download</string>
+    <string>&amp;Download</string>
    </property>
   </action>
   <action name="action_usdb_login">
@@ -590,7 +590,7 @@
      <normaloff>:/icons/faviconUSDB.png</normaloff>:/icons/faviconUSDB.png</iconset>
    </property>
    <property name="text">
-    <string>USDB Login</string>
+    <string>USDB &amp;Login</string>
    </property>
   </action>
   <action name="action_about">
@@ -599,7 +599,7 @@
      <normaloff>:/app/appicon_128x128.png</normaloff>:/app/appicon_128x128.png</iconset>
    </property>
    <property name="text">
-    <string>About</string>
+    <string>&amp;About</string>
    </property>
   </action>
   <action name="action_show_in_usdb">
@@ -608,7 +608,7 @@
      <normaloff>:/icons/faviconUSDB.png</normaloff>:/icons/faviconUSDB.png</iconset>
    </property>
    <property name="text">
-    <string>Show on USDB</string>
+    <string>Show on &amp;USDB</string>
    </property>
   </action>
   <action name="action_post_comment_in_usdb">
@@ -617,7 +617,7 @@
      <normaloff>:/icons/balloon.png</normaloff>:/icons/balloon.png</iconset>
    </property>
    <property name="text">
-    <string>Post Comment on USDB</string>
+    <string>Post &amp;Comment on USDB</string>
    </property>
   </action>
   <action name="action_open_song_folder">
@@ -626,7 +626,7 @@
      <normaloff>:/icons/folder_note.png</normaloff>:/icons/folder_note.png</iconset>
    </property>
    <property name="text">
-    <string>Open Song Folder</string>
+    <string>&amp;Open Song Folder</string>
    </property>
   </action>
   <action name="action_delete">
@@ -635,7 +635,7 @@
      <normaloff>:/icons/bin.png</normaloff>:/icons/bin.png</iconset>
    </property>
    <property name="text">
-    <string>Delete</string>
+    <string>D&amp;elete</string>
    </property>
    <property name="toolTip">
     <string>Move to system recycle bin</string>
@@ -650,7 +650,7 @@
      <normaloff>:/icons/pin.png</normaloff>:/icons/pin.png</iconset>
    </property>
    <property name="text">
-    <string>Pin</string>
+    <string>&amp;Pin</string>
    </property>
    <property name="toolTip">
     <string>Disable or reenable updates to local files</string>
@@ -662,7 +662,7 @@
      <normaloff>:/icons/minus-circle.png</normaloff>:/icons/minus-circle.png</iconset>
    </property>
    <property name="text">
-    <string>Abort Download</string>
+    <string>&amp;Abort Download</string>
    </property>
   </action>
   <action name="action_delete_saved_search">
@@ -720,7 +720,7 @@
      <normaloff>:/icons/karedi.png</normaloff>:/icons/karedi.png</iconset>
    </property>
    <property name="text">
-    <string>Karedi</string>
+    <string>&amp;Karedi</string>
    </property>
   </action>
   <action name="action_open_song_in_performous">
@@ -729,7 +729,7 @@
      <normaloff>:/icons/performous.png</normaloff>:/icons/performous.png</iconset>
    </property>
    <property name="text">
-    <string>Performous</string>
+    <string>&amp;Performous</string>
    </property>
   </action>
   <action name="action_open_song_in_usdx">
@@ -738,7 +738,7 @@
      <normaloff>:/icons/usdx.png</normaloff>:/icons/usdx.png</iconset>
    </property>
    <property name="text">
-    <string>UltraStar Deluxe</string>
+    <string>&amp;UltraStar Deluxe</string>
    </property>
   </action>
   <action name="action_open_song_in_ultrastar_manager">
@@ -747,7 +747,7 @@
      <normaloff>:/icons/ultrastar-manager.png</normaloff>:/icons/ultrastar-manager.png</iconset>
    </property>
    <property name="text">
-    <string>UltraStar Manager</string>
+    <string>UltraStar &amp;Manager</string>
    </property>
   </action>
   <action name="action_open_song_in_vocaluxe">
@@ -756,7 +756,7 @@
      <normaloff>:/icons/vocaluxe.png</normaloff>:/icons/vocaluxe.png</iconset>
    </property>
    <property name="text">
-    <string>Vocaluxe</string>
+    <string>&amp;Vocaluxe</string>
    </property>
   </action>
   <action name="action_open_song_in_yass_reloaded">
@@ -765,7 +765,7 @@
      <normaloff>:/icons/yass-reloaded.png</normaloff>:/icons/yass-reloaded.png</iconset>
    </property>
    <property name="text">
-    <string>YASS Reloaded</string>
+    <string>&amp;YASS Reloaded</string>
    </property>
   </action>
   <action name="action_rate_in_usdb">
@@ -782,7 +782,7 @@
   </action>
   <action name="action_rate_1star">
    <property name="text">
-    <string>★ – Unusable, requires a complete overhaul</string>
+    <string>&amp;1: ★ – Unusable, requires a complete overhaul</string>
    </property>
    <property name="toolTip">
     <string>unusable, needs a total rework</string>
@@ -790,7 +790,7 @@
   </action>
   <action name="action_rate_2stars">
    <property name="text">
-    <string>★★ – Barely usable, needs significant revisions</string>
+    <string>&amp;2: ★★ – Barely usable, needs significant revisions</string>
    </property>
    <property name="toolTip">
     <string>hardly usable, needs a lot of improvements</string>
@@ -798,7 +798,7 @@
   </action>
   <action name="action_rate_3stars">
    <property name="text">
-    <string>★★★ – Usable, but requires improvements</string>
+    <string>&amp;3: ★★★ – Usable, but requires improvements</string>
    </property>
    <property name="toolTip">
     <string>usable, but room for improvement</string>
@@ -806,7 +806,7 @@
   </action>
   <action name="action_rate_4stars">
    <property name="text">
-    <string>★★★★ – Very good, with minor areas for improvement</string>
+    <string>&amp;4: ★★★★ – Very good, with minor areas for improvement</string>
    </property>
    <property name="toolTip">
     <string>room for some improvements</string>
@@ -814,7 +814,7 @@
   </action>
   <action name="action_rate_5stars">
    <property name="text">
-    <string>★★★★★ – Excellent, no improvements needed</string>
+    <string>&amp;5: ★★★★★ – Excellent, no improvements needed</string>
    </property>
    <property name="toolTip">
     <string>simply perfect</string>
@@ -822,27 +822,27 @@
   </action>
   <action name="action_preview">
    <property name="text">
-    <string>Preview Song</string>
+    <string>Pre&amp;view Song</string>
    </property>
   </action>
   <action name="action_go_to_search">
    <property name="text">
-    <string>Go to Search</string>
+    <string>Go to &amp;Search</string>
    </property>
   </action>
   <action name="action_go_to_song_table">
    <property name="text">
-    <string>Go to Song Table</string>
+    <string>Go to Song &amp;Table</string>
    </property>
   </action>
   <action name="action_go_to_filters">
    <property name="text">
-    <string>Go to Filters</string>
+    <string>Go to &amp;Filters</string>
    </property>
   </action>
   <action name="action_go_to_filter_search">
    <property name="text">
-    <string>Go to Filter Search</string>
+    <string>Go to F&amp;ilter Search</string>
    </property>
   </action>
  </widget>

--- a/src/usdb_syncer/gui/forms/MainWindow.ui
+++ b/src/usdb_syncer/gui/forms/MainWindow.ui
@@ -307,11 +307,20 @@
      <string>View</string>
     </property>
    </widget>
+   <widget class="QMenu" name="menuGo">
+    <property name="title">
+     <string>Go</string>
+    </property>
+    <addaction name="action_go_to_search"/>
+    <addaction name="action_go_to_song_table"/>
+    <addaction name="action_go_to_filters"/>
+   </widget>
    <addaction name="menu_view"/>
    <addaction name="menu_songs"/>
    <addaction name="menu_usdb"/>
    <addaction name="menu_local"/>
    <addaction name="menu_tools"/>
+   <addaction name="menuGo"/>
    <addaction name="menu_about"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
@@ -813,6 +822,21 @@
   <action name="action_preview">
    <property name="text">
     <string>Preview Song</string>
+   </property>
+  </action>
+  <action name="action_go_to_search">
+   <property name="text">
+    <string>Go to Search</string>
+   </property>
+  </action>
+  <action name="action_go_to_song_table">
+   <property name="text">
+    <string>Go to Song Table</string>
+   </property>
+  </action>
+  <action name="action_go_to_filters">
+   <property name="text">
+    <string>Go to Filters</string>
    </property>
   </action>
  </widget>

--- a/src/usdb_syncer/gui/gui_utils.py
+++ b/src/usdb_syncer/gui/gui_utils.py
@@ -1,11 +1,7 @@
 """General-purpose utilities for the GUI."""
 
-from collections.abc import Callable
-from typing import Any
-
 import attrs
-from PySide6.QtCore import QObject, Qt
-from PySide6.QtGui import QKeySequence, QShortcut
+from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QAbstractScrollArea, QApplication
 
 
@@ -16,10 +12,6 @@ class Modifiers:
     ctrl: bool
     shift: bool
     alt: bool
-
-
-def set_shortcut(key: str, parent: QObject, func: Callable[[], Any]) -> None:
-    QShortcut(QKeySequence(key), parent).activated.connect(func)
 
 
 def scroll_to_bottom(scroll_area: QAbstractScrollArea) -> None:

--- a/src/usdb_syncer/gui/mw.py
+++ b/src/usdb_syncer/gui/mw.py
@@ -21,6 +21,7 @@ from usdb_syncer.gui.progress import run_with_progress
 from usdb_syncer.gui.report_dialog import ReportDialog
 from usdb_syncer.gui.search_tree.tree import FilterTree
 from usdb_syncer.gui.settings_dialog import SettingsDialog
+from usdb_syncer.gui.shortcuts import MainWindowShortcut, SongTableShortcut
 from usdb_syncer.gui.song_table.song_table import SongTable
 from usdb_syncer.gui.usdb_login_dialog import UsdbLoginDialog
 from usdb_syncer.logger import logger
@@ -89,73 +90,110 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def _setup_toolbar(self) -> None:
         self.menu_view.addAction(self.dock_search.toggleViewAction())
         self.menu_view.addAction(self.dock_log.toggleViewAction())
-        for action, func in (
-            (self.action_songs_download, self.table.download_selection),
-            (self.action_songs_abort, self.table.abort_selected_downloads),
-            (self.action_find_local_songs, self._select_local_songs),
-            (self.action_refetch_song_list, self._refetch_song_list),
-            (self.action_usdb_login, lambda: UsdbLoginDialog(self).show()),
-            (self.action_meta_tags, lambda: MetaTagsDialog(self).show()),
+        for action, func, shortcut in (
+            (
+                self.action_songs_download,
+                self.table.download_selection,
+                SongTableShortcut.DOWNLOAD,
+            ),
+            (self.action_songs_abort, self.table.abort_selected_downloads, None),
+            (self.action_find_local_songs, self._select_local_songs, None),
+            (self.action_refetch_song_list, self._refetch_song_list, None),
+            (self.action_usdb_login, lambda: UsdbLoginDialog(self).show(), None),
+            (self.action_meta_tags, lambda: MetaTagsDialog(self).show(), None),
             (
                 self.action_settings,
                 lambda: SettingsDialog(self, self.table.current_song()).show(),
+                None,
             ),
-            (self.action_about, lambda: AboutDialog(self).show()),
+            (self.action_about, lambda: AboutDialog(self).show(), None),
             (
                 self.action_generate_song_list,
                 lambda: ReportDialog(self, self.table).show(),
+                None,
             ),
-            (self.action_import_usdb_ids, self._import_usdb_ids_from_files),
-            (self.action_export_usdb_ids, self._export_usdb_ids_to_file),
-            (self.action_show_log, lambda: open_path_or_file(AppPaths.log.parent)),
-            (self.action_show_in_usdb, self._show_current_song_in_usdb),
-            (self.action_post_comment_in_usdb, self._show_comment_dialog),
-            (self.action_rate_1star, lambda: self._rate_in_usdb(1)),
-            (self.action_rate_2stars, lambda: self._rate_in_usdb(2)),
-            (self.action_rate_3stars, lambda: self._rate_in_usdb(3)),
-            (self.action_rate_4stars, lambda: self._rate_in_usdb(4)),
-            (self.action_rate_5stars, lambda: self._rate_in_usdb(5)),
-            (self.action_open_song_folder, self._open_current_song_folder),
+            (self.action_import_usdb_ids, self._import_usdb_ids_from_files, None),
+            (self.action_export_usdb_ids, self._export_usdb_ids_to_file, None),
+            (
+                self.action_show_log,
+                lambda: open_path_or_file(AppPaths.log.parent),
+                None,
+            ),
+            (self.action_show_in_usdb, self._show_current_song_in_usdb, None),
+            (self.action_post_comment_in_usdb, self._show_comment_dialog, None),
+            (self.action_rate_1star, lambda: self._rate_in_usdb(1), None),
+            (self.action_rate_2stars, lambda: self._rate_in_usdb(2), None),
+            (self.action_rate_3stars, lambda: self._rate_in_usdb(3), None),
+            (self.action_rate_4stars, lambda: self._rate_in_usdb(4), None),
+            (self.action_rate_5stars, lambda: self._rate_in_usdb(5), None),
+            (self.action_open_song_folder, self._open_current_song_folder, None),
             (
                 self.action_open_song_in_karedi,
                 lambda: self._open_current_song_in_app(settings.SupportedApps.KAREDI),
+                None,
             ),
             (
                 self.action_open_song_in_performous,
                 lambda: self._open_current_song_in_app(
                     settings.SupportedApps.PERFORMOUS
                 ),
+                None,
             ),
             (
                 self.action_open_song_in_ultrastar_manager,
                 lambda: self._open_current_song_in_app(
                     settings.SupportedApps.ULTRASTAR_MANAGER
                 ),
+                None,
             ),
             (
                 self.action_open_song_in_usdx,
                 lambda: self._open_current_song_in_app(settings.SupportedApps.USDX),
+                None,
             ),
             (
                 self.action_open_song_in_vocaluxe,
                 lambda: self._open_current_song_in_app(settings.SupportedApps.VOCALUXE),
+                None,
             ),
             (
                 self.action_open_song_in_yass_reloaded,
                 lambda: self._open_current_song_in_app(
                     settings.SupportedApps.YASS_RELOADED
                 ),
+                None,
             ),
-            (self.action_delete, self.table.delete_selected_songs),
-            (self.action_pin, self.table.set_pin_selected_songs),
-            (self.action_preview, self._show_preview_dialog),
+            (self.action_delete, self.table.delete_selected_songs, None),
+            (self.action_pin, self.table.set_pin_selected_songs, None),
+            (self.action_preview, self._show_preview_dialog, None),
+            (
+                self.action_go_to_search,
+                self._focus_search,
+                MainWindowShortcut.GO_TO_SEARCH,
+            ),
+            (
+                self.action_go_to_song_table,
+                self.table_view.setFocus,
+                MainWindowShortcut.GO_TO_SONG_TABLE,
+            ),
+            (
+                self.action_go_to_filters,
+                self.search_view.setFocus,
+                MainWindowShortcut.GO_TO_FILTERS,
+            ),
         ):
             action.triggered.connect(func)
+            if shortcut:
+                action.setShortcut(shortcut)
         self.menu_custom_data.aboutToShow.connect(self.table.build_custom_data_menu)
 
     def _setup_shortcuts(self) -> None:
-        gui_utils.set_shortcut("Ctrl+.", self, lambda: DebugConsole(self).show())
-        gui_utils.set_shortcut("Ctrl+F", self, self._focus_search)
+        MainWindowShortcut.OPEN_DEBUG_CONSOLE.connect(
+            self, lambda: DebugConsole(self).show()
+        )
+        SongTableShortcut.PLAY_SAMPLE.connect(
+            self.table_view, self.table.on_play_or_stop_sample
+        )
 
     def _setup_song_dir(self) -> None:
         self.song_dir = settings.get_song_dir()

--- a/src/usdb_syncer/gui/mw.py
+++ b/src/usdb_syncer/gui/mw.py
@@ -64,6 +64,10 @@ class MainWindow(Ui_MainWindow, QMainWindow):
         self.lineEdit_search.setFocus()
         self.lineEdit_search.selectAll()
 
+    def _focus_filter_search(self) -> None:
+        self.line_edit_search_filters.setFocus()
+        self.line_edit_search_filters.selectAll()
+
     def _setup_statusbar(self) -> None:
         self._status_label = QLabel(self)
         self.statusbar.addWidget(self._status_label)
@@ -96,7 +100,11 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                 self.table.download_selection,
                 SongTableShortcut.DOWNLOAD,
             ),
-            (self.action_songs_abort, self.table.abort_selected_downloads, None),
+            (
+                self.action_songs_abort,
+                self.table.abort_selected_downloads,
+                SongTableShortcut.ABORT_DOWNLOAD,
+            ),
             (self.action_find_local_songs, self._select_local_songs, None),
             (self.action_refetch_song_list, self._refetch_song_list, None),
             (self.action_usdb_login, lambda: UsdbLoginDialog(self).show(), None),
@@ -104,7 +112,7 @@ class MainWindow(Ui_MainWindow, QMainWindow):
             (
                 self.action_settings,
                 lambda: SettingsDialog(self, self.table.current_song()).show(),
-                None,
+                MainWindowShortcut.OPEN_PREFERNCES,
             ),
             (self.action_about, lambda: AboutDialog(self).show(), None),
             (
@@ -163,13 +171,26 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                 ),
                 None,
             ),
-            (self.action_delete, self.table.delete_selected_songs, None),
-            (self.action_pin, self.table.set_pin_selected_songs, None),
-            (self.action_preview, self._show_preview_dialog, None),
+            (
+                self.action_delete,
+                self.table.delete_selected_songs,
+                SongTableShortcut.TRASH_SONG,
+            ),
+            (
+                self.action_pin,
+                self.table.set_pin_selected_songs,
+                SongTableShortcut.PIN_SONG,
+            ),
+            (self.action_preview, self._show_preview_dialog, SongTableShortcut.PREVIEW),
             (
                 self.action_go_to_search,
                 self._focus_search,
                 MainWindowShortcut.GO_TO_SEARCH,
+            ),
+            (
+                self.action_go_to_filter_search,
+                self._focus_filter_search,
+                MainWindowShortcut.GO_TO_FILTER_SEARCH,
             ),
             (
                 self.action_go_to_song_table,
@@ -198,11 +219,15 @@ class MainWindow(Ui_MainWindow, QMainWindow):
     def _setup_song_dir(self) -> None:
         self.song_dir = settings.get_song_dir()
         self.lineEdit_song_dir.setText(str(self.song_dir))
-        self.pushButton_select_song_dir.clicked.connect(self._select_song_dir)
 
     def _setup_buttons(self) -> None:
         self.button_download.clicked.connect(self.table.download_selection)
+        self.pushButton_select_song_dir.setShortcut(MainWindowShortcut.SELECT_FOLDER)
+        self.pushButton_select_song_dir.clicked.connect(self._select_song_dir)
+        self.pushButton_select_song_dir.setToolTip(MainWindowShortcut.SELECT_FOLDER)
+        self.button_pause.setShortcut(MainWindowShortcut.PAUSE_DOWNLOAD)
         self.button_pause.clicked.connect(DownloadManager.set_pause)
+        self.button_pause.setToolTip(MainWindowShortcut.PAUSE_DOWNLOAD)
 
     def _on_log_filter_changed(self) -> None:
         messages = []

--- a/src/usdb_syncer/gui/mw.py
+++ b/src/usdb_syncer/gui/mw.py
@@ -202,6 +202,11 @@ class MainWindow(Ui_MainWindow, QMainWindow):
                 self.search_view.setFocus,
                 MainWindowShortcut.GO_TO_FILTERS,
             ),
+            (
+                self.action_go_to_open_song_menu,
+                self._show_open_song_menu,
+                SongTableShortcut.OPEN_SONG,
+            ),
         ):
             action.triggered.connect(func)
             if shortcut:
@@ -222,6 +227,8 @@ class MainWindow(Ui_MainWindow, QMainWindow):
 
     def _setup_buttons(self) -> None:
         self.button_download.clicked.connect(self.table.download_selection)
+        # no need to actually set shortcut because there is an identical action
+        self.button_download.setToolTip(SongTableShortcut.DOWNLOAD)
         self.pushButton_select_song_dir.setShortcut(MainWindowShortcut.SELECT_FOLDER)
         self.pushButton_select_song_dir.clicked.connect(self._select_song_dir)
         self.pushButton_select_song_dir.setToolTip(MainWindowShortcut.SELECT_FOLDER)
@@ -392,6 +399,10 @@ class MainWindow(Ui_MainWindow, QMainWindow):
 
     def _open_current_song_in_app(self, app: settings.SupportedApps) -> None:
         self._open_current_song(lambda path: settings.SupportedApps.open_app(app, path))
+
+    def _show_open_song_menu(self) -> None:
+        pos = self.mapToGlobal(self.rect().center())
+        self.menu_open_song_in.popup(pos)
 
     def closeEvent(self, event: QtGui.QCloseEvent) -> None:  # noqa: N802
         def on_done(result: progress.Result) -> None:

--- a/src/usdb_syncer/gui/settings_dialog.py
+++ b/src/usdb_syncer/gui/settings_dialog.py
@@ -7,7 +7,7 @@ from typing import ClassVar, assert_never
 from PySide6 import QtWidgets
 from PySide6.QtWidgets import QDialog, QDialogButtonBox, QFileDialog, QWidget
 
-from usdb_syncer import SongId, path_template, settings
+from usdb_syncer import SongId, events, path_template, settings
 from usdb_syncer.gui import icons, theme
 from usdb_syncer.gui.forms.SettingsDialog import Ui_Dialog
 from usdb_syncer.path_template import PathTemplate
@@ -350,6 +350,7 @@ class SettingsDialog(Ui_Dialog, QDialog):
             settings.SupportedApps.YASS_RELOADED,
             self.lineEdit_path_yass_reloaded.text(),
         )
+        events.PreferencesChanged().post()
         return True
 
     def _on_tab_changed(self, index: int) -> None:

--- a/src/usdb_syncer/gui/shortcuts.py
+++ b/src/usdb_syncer/gui/shortcuts.py
@@ -36,6 +36,7 @@ class SongTableShortcut(Shortcut):
     PIN_SONG = "Ctrl+P"
     PLAY_SAMPLE = "Space"
     PREVIEW = "Shift+Space"
+    OPEN_SONG = "Ctrl+K"
 
 
 class DebugConsoleShortcut(Shortcut):

--- a/src/usdb_syncer/gui/shortcuts.py
+++ b/src/usdb_syncer/gui/shortcuts.py
@@ -32,7 +32,7 @@ class SongTableShortcut(Shortcut):
 
     DOWNLOAD = "Ctrl+Return"
     ABORT_DOWNLOAD = "Ctrl+Alt+Return"
-    TRASH_SONG = "Ctrl+Delete"
+    TRASH_SONG = "Ctrl+D"
     PIN_SONG = "Ctrl+P"
     PLAY_SAMPLE = "Space"
     PREVIEW = "Shift+Space"

--- a/src/usdb_syncer/gui/shortcuts.py
+++ b/src/usdb_syncer/gui/shortcuts.py
@@ -1,0 +1,41 @@
+"""Keyboard shortcut definitions and utils."""
+
+import enum
+from collections.abc import Callable
+
+from PySide6.QtCore import QObject
+from PySide6.QtGui import QKeySequence, QShortcut
+
+
+class Shortcut(enum.StrEnum):
+    """Helper for setting keyboard shortcuts."""
+
+    def connect(self, parent: QObject, func: Callable[[], None]) -> None:
+        QShortcut(QKeySequence(self.value), parent).activated.connect(func)
+
+
+class MainWindowShortcut(Shortcut):
+    """Keyboard shortcuts within the main window."""
+
+    PAUSE_DOWNLOAD = "Ctrl+Shift+Return"
+    OPEN_DEBUG_CONSOLE = "Ctrl+."
+    GO_TO_SEARCH = "Ctrl+F"
+    GO_TO_SONG_TABLE = "Ctrl+T"
+    GO_TO_FILTERS = "Ctrl+S"
+
+
+class SongTableShortcut(Shortcut):
+    """Keyboard shortcuts usable when the song table is focused."""
+
+    DOWNLOAD = "Ctrl+Return"
+    ABORT_DOWNLOAD = "Ctrl+Alt+Return"
+    PLAY_SAMPLE = "Space"
+
+
+class DebugConsoleShortcut(Shortcut):
+    """Keyboard shortcuts within the debug console window."""
+
+    EXECUTE = "Ctrl+Return"
+    EXECUTE_PRINT = "Ctrl+Shift+Return"
+    CLEAR_OUTPUT = "Ctrl+L"
+    CLEAR_INPUT = "Ctrl+Shift+L"

--- a/src/usdb_syncer/gui/shortcuts.py
+++ b/src/usdb_syncer/gui/shortcuts.py
@@ -36,7 +36,7 @@ class SongTableShortcut(Shortcut):
     PIN_SONG = "Ctrl+P"
     PLAY_SAMPLE = "Space"
     PREVIEW = "Shift+Space"
-    OPEN_SONG = "Ctrl+K"
+    OPEN_SONG = "Ctrl+Shift+O"
 
 
 class DebugConsoleShortcut(Shortcut):

--- a/src/usdb_syncer/gui/shortcuts.py
+++ b/src/usdb_syncer/gui/shortcuts.py
@@ -17,11 +17,14 @@ class Shortcut(enum.StrEnum):
 class MainWindowShortcut(Shortcut):
     """Keyboard shortcuts within the main window."""
 
+    SELECT_FOLDER = "Ctrl+O"
     PAUSE_DOWNLOAD = "Ctrl+Shift+Return"
+    OPEN_PREFERNCES = "Ctrl+,"
     OPEN_DEBUG_CONSOLE = "Ctrl+."
     GO_TO_SEARCH = "Ctrl+F"
     GO_TO_SONG_TABLE = "Ctrl+T"
     GO_TO_FILTERS = "Ctrl+S"
+    GO_TO_FILTER_SEARCH = "Ctrl+Shift+F"
 
 
 class SongTableShortcut(Shortcut):
@@ -29,7 +32,10 @@ class SongTableShortcut(Shortcut):
 
     DOWNLOAD = "Ctrl+Return"
     ABORT_DOWNLOAD = "Ctrl+Alt+Return"
+    TRASH_SONG = "Ctrl+Delete"
+    PIN_SONG = "Ctrl+P"
     PLAY_SAMPLE = "Space"
+    PREVIEW = "Shift+Space"
 
 
 class DebugConsoleShortcut(Shortcut):

--- a/src/usdb_syncer/gui/song_table/song_table.py
+++ b/src/usdb_syncer/gui/song_table/song_table.py
@@ -48,6 +48,8 @@ class SongTable:
         mw.table_view.selectionModel().currentChanged.connect(
             self._on_current_song_changed
         )
+        self._set_app_actions_visible()
+        events.PreferencesChanged.subscribe(lambda _: self._set_app_actions_visible())
         events.SongChanged.subscribe(self._on_song_changed)
         self._setup_search_timer()
         gui_events.TreeFilterChanged.subscribe(self._on_tree_filter_changed)
@@ -250,26 +252,25 @@ class SongTable:
             self.mw.menu_custom_data,
         ):
             action.setEnabled(song.is_local())
-        self.mw.action_open_song_in_karedi.setVisible(
-            settings.get_app_path(settings.SupportedApps.KAREDI) is not None
-        )
-        self.mw.action_open_song_in_performous.setVisible(
-            settings.get_app_path(settings.SupportedApps.PERFORMOUS) is not None
-        )
-        self.mw.action_open_song_in_ultrastar_manager.setVisible(
-            settings.get_app_path(settings.SupportedApps.ULTRASTAR_MANAGER) is not None
-        )
-        self.mw.action_open_song_in_usdx.setVisible(
-            settings.get_app_path(settings.SupportedApps.USDX) is not None
-        )
-        self.mw.action_open_song_in_vocaluxe.setVisible(
-            settings.get_app_path(settings.SupportedApps.VOCALUXE) is not None
-        )
-        self.mw.action_open_song_in_yass_reloaded.setVisible(
-            settings.get_app_path(settings.SupportedApps.YASS_RELOADED) is not None
-        )
         self.mw.action_pin.setChecked(song.is_pinned())
         self.mw.action_songs_abort.setEnabled(song.status.can_be_aborted())
+
+    def _set_app_actions_visible(self) -> None:
+        for action, app in (
+            (self.mw.action_open_song_in_karedi, settings.SupportedApps.KAREDI),
+            (self.mw.action_open_song_in_performous, settings.SupportedApps.PERFORMOUS),
+            (
+                self.mw.action_open_song_in_ultrastar_manager,
+                settings.SupportedApps.ULTRASTAR_MANAGER,
+            ),
+            (self.mw.action_open_song_in_usdx, settings.SupportedApps.USDX),
+            (self.mw.action_open_song_in_vocaluxe, settings.SupportedApps.VOCALUXE),
+            (
+                self.mw.action_open_song_in_yass_reloaded,
+                settings.SupportedApps.YASS_RELOADED,
+            ),
+        ):
+            action.setVisible(settings.get_app_path(app) is not None)
 
     def delete_selected_songs(self) -> None:
         with db.transaction():

--- a/src/usdb_syncer/gui/song_table/song_table.py
+++ b/src/usdb_syncer/gui/song_table/song_table.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 import send2trash
 from PySide6 import QtCore, QtMultimedia, QtWidgets
 from PySide6.QtCore import QItemSelectionModel, Qt
-from PySide6.QtGui import QAction, QCursor, QKeySequence, QShortcut
+from PySide6.QtGui import QAction, QCursor
 
 from usdb_syncer import SongId, db, events, media_player, settings, sync_meta
 from usdb_syncer.gui import events as gui_events
@@ -53,9 +53,6 @@ class SongTable:
         gui_events.TreeFilterChanged.subscribe(self._on_tree_filter_changed)
         gui_events.TextFilterChanged.subscribe(self._on_text_filter_changed)
         gui_events.SavedSearchRestored.subscribe(self._on_saved_search_restored)
-        QShortcut(QKeySequence(Qt.Key.Key_Space), self._view).activated.connect(
-            self._on_space
-        )
 
     def _on_playback_state_changed(
         self, state: QtMultimedia.QMediaPlayer.PlaybackState
@@ -82,7 +79,7 @@ class SongTable:
         logger.error(f"Failed to play back source: {source}")
         logger.debug(self._media_player.errorString())
 
-    def _on_space(self) -> None:
+    def on_play_or_stop_sample(self) -> None:
         if song := self.current_song():
             self._play_or_stop_sample(song)
 


### PR DESCRIPTION
Closes #33.

This adds accelerators for all actions and shortcuts for the most important ones.
The shortcut for opening a song in an external app relies on accelerators for picking the app in a second step. On a Mac, where they're not supported, you can use arrows keys plus Return. As for a full cross-platform solution, that's the best I got.