### PR TITLE
Parse meta tags case insensitively.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## Features
 
-. Added Tune Perfect (https://tuneperfect.org/) to supported apps. You can now open a selected song in Tune Perfect directly via the Syncer.
+- Added Tune Perfect (https://tuneperfect.org/) to supported apps. You can now open a selected song in Tune Perfect directly via the Syncer.
+- Meta tags parsing is now case insensitive.
  
 ## Fixes
 

--- a/src/usdb_syncer/meta_tags.py
+++ b/src/usdb_syncer/meta_tags.py
@@ -173,6 +173,7 @@ class MetaTags:
     def _parse_key_value_pair(  # noqa: C901
         self, key: str, value: str, logger: Logger
     ) -> None:
+        key = key.lower()
         value = decode_meta_tag_value(value)
         match key:
             case "v":


### PR DESCRIPTION
This makes meta tags parsing more robust, e.g. it accepts `P1` where pereviously only `p1` was accepted.