### PR TITLE
Use newly available `lastchange` info in song list

### DIFF
--- a/src/usdb_syncer/db/__init__.py
+++ b/src/usdb_syncer/db/__init__.py
@@ -22,7 +22,7 @@ from usdb_syncer.logger import logger
 
 from . import sql
 
-SCHEMA_VERSION = 6
+SCHEMA_VERSION = 7
 
 # https://www.sqlite.org/limits.html
 _SQL_VARIABLES_LIMIT = 32766
@@ -193,6 +193,7 @@ class SongOrder(enum.Enum):
     VIDEO = enum.auto()
     COVER = enum.auto()
     BACKGROUND = enum.auto()
+    LASTCHANGE = enum.auto()
     STATUS = enum.auto()
 
     def sql(self) -> str | None:  # noqa: C901
@@ -241,6 +242,8 @@ class SongOrder(enum.Enum):
                 return "cover.sync_meta_id IS NULL"
             case SongOrder.BACKGROUND:
                 return "background.sync_meta_id IS NULL"
+            case SongOrder.LASTCHANGE:
+                return "usdb_song.lastchange"
             case SongOrder.STATUS:
                 return (
                     "coalesce(session_usdb_song.status, sync_meta.mtime,"
@@ -519,6 +522,7 @@ class UsdbSongParams:
     """Parameters for inserting or updating a USDB song."""
 
     song_id: SongId
+    lastchange: int
     artist: str
     title: str
     language: str
@@ -731,6 +735,7 @@ class SyncMetaParams:
 
     sync_meta_id: SyncMetaId
     song_id: SongId
+    lastchange: int
     path: str
     mtime: int
     meta_tags: str

--- a/src/usdb_syncer/db/sql/7_migration.sql
+++ b/src/usdb_syncer/db/sql/7_migration.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE
+    usdb_song
+ADD
+    lastchange INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE
+    sync_meta
+ADD
+    lastchange INTEGER NOT NULL DEFAULT 0;
+
+COMMIT;

--- a/src/usdb_syncer/db/sql/select_sync_meta.sql
+++ b/src/usdb_syncer/db/sql/select_sync_meta.sql
@@ -1,6 +1,7 @@
 SELECT
     sync_meta.sync_meta_id,
     sync_meta.song_id,
+    sync_meta.lastchange,
     sync_meta.path,
     sync_meta.mtime,
     sync_meta.meta_tags,

--- a/src/usdb_syncer/db/sql/select_usdb_song.sql
+++ b/src/usdb_syncer/db/sql/select_usdb_song.sql
@@ -1,5 +1,6 @@
 SELECT
     usdb_song.song_id,
+    usdb_song.lastchange,
     usdb_song.artist,
     usdb_song.title,
     usdb_song.language,

--- a/src/usdb_syncer/db/sql/upsert_sync_meta.sql
+++ b/src/usdb_syncer/db/sql/upsert_sync_meta.sql
@@ -3,6 +3,7 @@ INSERT INTO
 VALUES (
     :sync_meta_id,
     :song_id,
+    :lastchange,
     :path,
     :mtime,
     :meta_tags,
@@ -10,6 +11,7 @@ VALUES (
 )
 ON CONFLICT (sync_meta_id) DO UPDATE SET
     song_id = :song_id,
+    lastchange = :lastchange,
     path = :path,
     mtime = :mtime,
     meta_tags = :meta_tags,

--- a/src/usdb_syncer/db/sql/upsert_usdb_song.sql
+++ b/src/usdb_syncer/db/sql/upsert_usdb_song.sql
@@ -1,6 +1,7 @@
 INSERT INTO
     usdb_song (
         song_id,
+        lastchange,
         artist,
         title,
         language,
@@ -17,6 +18,7 @@ INSERT INTO
 VALUES
     (
         :song_id,
+        :lastchange,
         :artist,
         :title,
         :language,
@@ -32,6 +34,7 @@ VALUES
     ) ON CONFLICT (song_id) DO
 UPDATE
 SET
+    lastchange = :lastchange,
     artist = :artist,
     title = :title,
     language = :language,

--- a/src/usdb_syncer/gui/settings_dialog.py
+++ b/src/usdb_syncer/gui/settings_dialog.py
@@ -16,6 +16,7 @@ from usdb_syncer.usdb_song import UsdbSong
 
 _FALLBACK_SONG = UsdbSong(
     song_id=SongId(3715),
+    lastchange=0,
     artist="Queen",
     title="Bohemian Rhapsody",
     genre="Genre",

--- a/src/usdb_syncer/gui/song_table/column.py
+++ b/src/usdb_syncer/gui/song_table/column.py
@@ -36,6 +36,7 @@ class Column(IntEnum):
     VIDEO = enum.auto()
     COVER = enum.auto()
     BACKGROUND = enum.auto()
+    LASTCHANGE = enum.auto()
     DOWNLOAD_STATUS = enum.auto()
 
     def display_data(self) -> str | None:  # noqa: C901
@@ -58,6 +59,8 @@ class Column(IntEnum):
                 return "Creator"
             case Column.TAGS:
                 return "Tags"
+            case Column.LASTCHANGE:
+                return "Last Change"
             case Column.DOWNLOAD_STATUS:
                 return "Status"
             case (
@@ -114,6 +117,8 @@ class Column(IntEnum):
                 icon = Icon.COVER
             case Column.BACKGROUND:
                 icon = Icon.BACKGROUND
+            case Column.LASTCHANGE:
+                icon = Icon.CALENDAR  # fixme
             case Column.DOWNLOAD_STATUS:
                 icon = Icon.DOWNLOAD
             case Column.PINNED:
@@ -138,6 +143,7 @@ class Column(IntEnum):
                 | Column.GENRE
                 | Column.CREATOR
                 | Column.TAGS
+                | Column.LASTCHANGE
             ):
                 return None
             case (
@@ -193,6 +199,8 @@ class Column(IntEnum):
                 return db.SongOrder.COVER
             case Column.BACKGROUND:
                 return db.SongOrder.BACKGROUND
+            case Column.LASTCHANGE:
+                return db.SongOrder.LASTCHANGE
             case Column.DOWNLOAD_STATUS:
                 return db.SongOrder.STATUS
             case unreachable:
@@ -239,6 +247,8 @@ class Column(IntEnum):
                 return Column.COVER
             case db.SongOrder.BACKGROUND:
                 return Column.BACKGROUND
+            case db.SongOrder.LASTCHANGE:
+                return Column.LASTCHANGE
             case db.SongOrder.STATUS:
                 return Column.DOWNLOAD_STATUS
             case unreachable:

--- a/src/usdb_syncer/gui/song_table/table_model.py
+++ b/src/usdb_syncer/gui/song_table/table_model.py
@@ -148,9 +148,11 @@ def _display_data(song: UsdbSong, column: int) -> str | None:  # noqa: C901
             return song.creator
         case Column.TAGS:
             return song.tags
+        case Column.LASTCHANGE:
+            return utils.format_timestamp_utc(song.lastchange)
         case Column.DOWNLOAD_STATUS:
             return (
-                utils.format_timestamp(song.sync_meta.mtime)
+                utils.format_timestamp_mtime(song.sync_meta.mtime)
                 if song.sync_meta and song.status is DownloadStatus.NONE
                 else str(song.status)
             )
@@ -180,6 +182,7 @@ def _decoration_data(song: UsdbSong, column: int) -> QIcon | None:  # noqa: C901
             | Column.GOLDEN_NOTES
             | Column.RATING
             | Column.VIEWS
+            | Column.LASTCHANGE
             | Column.DOWNLOAD_STATUS
             | Column.YEAR
             | Column.GENRE

--- a/src/usdb_syncer/song_loader.py
+++ b/src/usdb_syncer/song_loader.py
@@ -743,6 +743,7 @@ def _write_sync_meta(ctx: _Context) -> None:
     ctx.song.sync_meta = SyncMeta(
         sync_meta_id=sync_meta_id,
         song_id=ctx.song.song_id,
+        lastchange=ctx.song.lastchange,
         path=ctx.locations.target_path(file=sync_meta_id.to_filename()),
         mtime=0,
         meta_tags=ctx.txt.meta_tags,

--- a/src/usdb_syncer/sync_meta.py
+++ b/src/usdb_syncer/sync_meta.py
@@ -85,6 +85,7 @@ class SyncMeta:
 
     sync_meta_id: SyncMetaId
     song_id: SongId
+    lastchange: int
     path: Path
     mtime: int
     meta_tags: MetaTags
@@ -102,6 +103,7 @@ class SyncMeta:
         return cls(
             sync_meta_id=sync_meta_id,
             song_id=song_id,
+            lastchange=0,
             path=folder.joinpath(sync_meta_id.to_filename()),
             mtime=0,
             meta_tags=meta_tags,
@@ -127,6 +129,7 @@ class SyncMeta:
             meta = cls(
                 sync_meta_id=sync_meta_id,
                 song_id=SongId(dct["song_id"]),
+                lastchange=int(dct["lastchange"]),
                 path=path,
                 mtime=utils.get_mtime(path),
                 meta_tags=MetaTags.parse(dct["meta_tags"], logger),
@@ -148,20 +151,21 @@ class SyncMeta:
 
     @classmethod
     def from_db_row(cls, row: tuple) -> SyncMeta:
-        assert len(row) == 21
+        assert len(row) == 22
         meta = cls(
             sync_meta_id=SyncMetaId(row[0]),
             song_id=SongId(row[1]),
-            path=Path(row[2]),
-            mtime=row[3],
-            meta_tags=MetaTags.parse(row[4], logger),
-            pinned=bool(row[5]),
+            lastchange=row[2],
+            path=Path(row[3]),
+            mtime=row[4],
+            meta_tags=MetaTags.parse(row[5], logger),
+            pinned=bool(row[6]),
         )
-        meta.txt = ResourceFile.from_db_row(row[6:9])
-        meta.audio = ResourceFile.from_db_row(row[9:12])
-        meta.video = ResourceFile.from_db_row(row[12:15])
-        meta.cover = ResourceFile.from_db_row(row[15:18])
-        meta.background = ResourceFile.from_db_row(row[18:])
+        meta.txt = ResourceFile.from_db_row(row[7:10])
+        meta.audio = ResourceFile.from_db_row(row[10:13])
+        meta.video = ResourceFile.from_db_row(row[13:16])
+        meta.cover = ResourceFile.from_db_row(row[16:19])
+        meta.background = ResourceFile.from_db_row(row[19:])
         meta.custom_data = CustomData(db.get_custom_data(meta.sync_meta_id))
         return meta
 
@@ -234,6 +238,7 @@ class SyncMeta:
         return db.SyncMetaParams(
             sync_meta_id=self.sync_meta_id,
             song_id=self.song_id,
+            lastchange=self.lastchange,
             path=self.path.as_posix(),
             mtime=self.mtime,
             meta_tags=str(self.meta_tags),

--- a/src/usdb_syncer/usdb_scraper.py
+++ b/src/usdb_syncer/usdb_scraper.py
@@ -26,19 +26,20 @@ from usdb_syncer.usdb_song import UsdbSong
 from usdb_syncer.utils import extract_youtube_id, normalize
 
 SONG_LIST_ROW_REGEX = re.compile(
+    r'<tr class="list_tr\d"\s+data-songid="(?P<song_id>\d+)"\s+'
+    r'data-lastchange="(?P<lastchange>\d+)"[^>]*?>\s*'
     r'<td(?:.*?<source src="(?P<sample_url>.*?)".*?)?></td>'
-    r'<td onclick="show_detail\((?P<song_id>\d+)\)".*?>'
-    r'<img src="(?P<cover_url>.*?)".*?></td>'
-    r'<td onclick="show_detail\(\d+\)">(?P<artist>.*?)</td>\n'
-    r'<td onclick="show_detail\(\d+\)"><a href=.*?>(?P<title>.*?)</td>\n'
-    r'<td onclick="show_detail\(\d+\)">(?P<genre>.*?)</td>\n'
-    r'<td onclick="show_detail\(\d+\)">(?P<year>.*?)</td>\n'
-    r'<td onclick="show_detail\(\d+\)">(?P<edition>.*?)</td>\n'
-    r'<td onclick="show_detail\(\d+\)">(?P<golden_notes>.*?)</td>\n'
-    r'<td onclick="show_detail\(\d+\)">(?P<language>.*?)</td>\n'
-    r'<td onclick="show_detail\(\d+\)">(?P<creator>.*?)</td>\n'
-    r'<td onclick="show_detail\(\d+\)">(?P<rating>.*?)</td>\n'
-    r'<td onclick="show_detail\(\d+\)">(?P<views>.*?)</td>'
+    r'<td[^>]*?><img src="(?P<cover_url>.*?)".*?></td>'
+    r"<td[^>]*?>(?P<artist>.*?)</td>\n"
+    r"<td[^>]*?><a href=.*?>(?P<title>.*?)</td>\n"
+    r"<td[^>]*?>(?P<genre>.*?)</td>\n"
+    r"<td[^>]*?>(?P<year>.*?)</td>\n"
+    r"<td[^>]*?>(?P<edition>.*?)</td>\n"
+    r"<td[^>]*?>(?P<golden_notes>.*?)</td>\n"
+    r"<td[^>]*?>(?P<language>.*?)</td>\n"
+    r"<td[^>]*?>(?P<creator>.*?)</td>\n"
+    r"<td[^>]*?>(?P<rating>.*?)</td>\n"
+    r"<td[^>]*?>(?P<views>.*?)</td>"
 )
 WELCOME_REGEX = re.compile(
     r"<td class='row3' colspan='2'>\s*<span class='gen'>([^<]+) <b>([^<]+)</b>"
@@ -358,8 +359,9 @@ def _parse_songs_from_songlist(html: str) -> Iterator[UsdbSong]:
     return (
         UsdbSong.from_html(
             _usdb_strings_from_html(html),
-            sample_url=match["sample_url"] or "",
             song_id=match["song_id"],
+            lastchange=match["lastchange"],
+            sample_url=match["sample_url"] or "",
             artist=match["artist"],
             title=match["title"],
             genre=match["genre"],

--- a/src/usdb_syncer/usdb_song.py
+++ b/src/usdb_syncer/usdb_song.py
@@ -20,6 +20,7 @@ class UsdbSong:
     """Meta data about a song that USDB shows in the result list."""
 
     song_id: SongId
+    lastchange: int
     artist: str
     title: str
     genre: str
@@ -49,6 +50,7 @@ class UsdbSong:
         strings: type[UsdbStrings],
         *,
         song_id: str,
+        lastchange: str,
         artist: str,
         title: str,
         genre: str,
@@ -63,6 +65,7 @@ class UsdbSong:
     ) -> UsdbSong:
         return cls(
             song_id=SongId.parse(song_id),
+            lastchange=int(lastchange),
             artist=artist,
             title=title,
             genre=genre,
@@ -78,24 +81,25 @@ class UsdbSong:
 
     @classmethod
     def from_db_row(cls, song_id: SongId, row: tuple) -> UsdbSong:
-        assert len(row) == 36
+        assert len(row) == 37
         return cls(
             song_id=song_id,
-            artist=row[1],
-            title=row[2],
-            language=row[3],
-            edition=row[4],
-            golden_notes=bool(row[5]),  # else would be 0/1 instead of False/True
-            rating=row[6],
-            views=row[7],
-            sample_url=row[8],
-            year=row[9],
-            genre=row[10],
-            creator=row[11],
-            tags=row[12],
-            status=DownloadStatus(row[13]),
-            is_playing=bool(row[14]),
-            sync_meta=None if row[15] is None else SyncMeta.from_db_row(row[15:]),
+            lastchange=row[1],
+            artist=row[2],
+            title=row[3],
+            language=row[4],
+            edition=row[5],
+            golden_notes=bool(row[6]),  # else would be 0/1 instead of False/True
+            rating=row[7],
+            views=row[8],
+            sample_url=row[9],
+            year=row[10],
+            genre=row[11],
+            creator=row[12],
+            tags=row[13],
+            status=DownloadStatus(row[14]),
+            is_playing=bool(row[15]),
+            sync_meta=None if row[16] is None else SyncMeta.from_db_row(row[16:]),
         )
 
     @classmethod
@@ -145,6 +149,7 @@ class UsdbSong:
     def db_params(self) -> db.UsdbSongParams:
         return db.UsdbSongParams(
             song_id=self.song_id,
+            lastchange=self.lastchange,
             artist=self.artist,
             title=self.title,
             language=self.language,

--- a/src/usdb_syncer/utils.py
+++ b/src/usdb_syncer/utils.py
@@ -293,10 +293,17 @@ def get_mtime(path: Path) -> int:
 
 
 @functools.cache
-def format_timestamp(micros: int) -> str:
+def format_timestamp_mtime(micros: int) -> str:
     return datetime.datetime.fromtimestamp(micros / 1_000_000).strftime(
         "%Y-%m-%d %H:%M:%S"
     )
+
+
+@functools.cache
+def format_timestamp_utc(timestamp: int) -> str:
+    return datetime.datetime.fromtimestamp(
+        timestamp, tz=datetime.timezone.utc
+    ).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def get_latest_version() -> str | None:


### PR DESCRIPTION
This PR
- adapts the song list parser to parse lastchange and song_id from `<tr> parameters
- writes the `lastchange` info to the sync meta file and into the db
- migrates the db to new schema 7 reflecting these changes
- adds a new sortable column in the song table that displays `lastchange` as UTC time