### PR TITLE
Fix zero length notes if there is room.

### DIFF
--- a/src/usdb_syncer/song_txt/__init__.py
+++ b/src/usdb_syncer/song_txt/__init__.py
@@ -126,6 +126,7 @@ class SongTxt:
         self.fix_first_timestamp()
         self.fix_low_bpm()
         self.notes.fix_overlapping_and_touching_notes(self.logger)
+        self.notes.fix_zero_length_notes(self.logger)
         self.notes.fix_pitch_values(self.logger)
         self.notes.fix_apostrophes(self.logger)
         self.headers.fix_apostrophes(self.logger)

--- a/src/usdb_syncer/song_txt/tracks.py
+++ b/src/usdb_syncer/song_txt/tracks.py
@@ -378,6 +378,14 @@ class Tracks:
             if fixed:
                 logger.debug(f"FIX: Gap after note {current_note.start} fixed.")
 
+    def fix_zero_length_notes(self, logger: Logger) -> None:
+        for current_note, next_note in self.consecutive_notes():
+            if (current_note.duration == 0) and (
+                next_note.start >= current_note.end() + 2
+            ):
+                current_note.duration = 1
+                logger.debug(f"FIX: Zero-length note at {current_note.start} fixed.")
+
     def fix_pitch_values(self, logger: Logger) -> None:
         min_pitch = min(note.pitch for note in self.all_notes())
         octave_shift = min_pitch // 12


### PR DESCRIPTION
Duration is set to 1 so at least they are not ignored / set to freestyle.