### PR TITLE
Replace appdirs with platformdirs

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -13,18 +13,6 @@ files = [
 ]
 
 [[package]]
-name = "appdirs"
-version = "1.4.4"
-description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
-    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
-]
-
-[[package]]
 name = "attrs"
 version = "25.3.0"
 description = "Classes Without Boilerplate"
@@ -1261,7 +1249,7 @@ version = "4.3.8"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4"},
     {file = "platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc"},
@@ -2149,4 +2137,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">3.10,<3.13"
-content-hash = "98e27be6513ca6643f05c125fd0855170071b40e7fb3c7222a2eb4298a15d62d"
+content-hash = "ac0f6049888c04a1ed25310d3099db72223fad377fcd1c05a5d9ec970a7a84ad"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ poetry-dynamic-versioning = { version = ">=1.0.0,<2.0.0", extras = ["plugin"] }
 
 [tool.poetry.dependencies]
 python = ">3.10,<3.13"
-appdirs = "*"
 attrs = "*"
 beautifulsoup4 = "*"
 ffmpeg-normalize = ">=1.27"
@@ -31,6 +30,7 @@ mutagen = "*"
 numpy = "^2.2.5"
 packaging = "*"
 pillow = ">=10"
+platformdirs = "*"
 PySide6 = "*"
 reportlab = "*"
 requests = "*"

--- a/src/usdb_syncer/utils.py
+++ b/src/usdb_syncer/utils.py
@@ -16,9 +16,9 @@ from typing import ClassVar
 
 import requests
 import send2trash
-from appdirs import AppDirs
 from bs4 import BeautifulSoup, Tag
 from packaging import version
+from platformdirs import PlatformDirs
 from unidecode import unidecode
 
 import usdb_syncer
@@ -26,7 +26,7 @@ from usdb_syncer import constants, errors, settings
 from usdb_syncer.logger import logger
 
 CACHE_LIFETIME = 60 * 60
-_app_dirs = AppDirs("usdb_syncer", "bohning")
+_platform_dirs = PlatformDirs("usdb_syncer", "bohning")
 
 
 # https://pyinstaller.org/en/stable/runtime-information.html#run-time-information
@@ -110,11 +110,11 @@ def get_first_alphanum_upper(text: str) -> str | None:
 class AppPaths:
     """App data paths."""
 
-    log = Path(_app_dirs.user_data_dir, "usdb_syncer.log")
-    db = Path(_app_dirs.user_data_dir, "usdb_syncer.db")
-    addons = Path(_app_dirs.user_data_dir, "addons")
-    song_list = Path(_app_dirs.user_cache_dir, "available_songs.json")
-    profile = Path(_app_dirs.user_cache_dir, "usdb_syncer.prof")
+    log = Path(_platform_dirs.user_data_dir, "usdb_syncer.log")
+    db = Path(_platform_dirs.user_data_dir, "usdb_syncer.db")
+    addons = Path(_platform_dirs.user_data_dir, "addons")
+    song_list = Path(_platform_dirs.user_cache_dir, "available_songs.json")
+    profile = Path(_platform_dirs.user_cache_dir, "usdb_syncer.prof")
     shared = (_root() / "shared") if IS_SOURCE else None
 
     @classmethod


### PR DESCRIPTION
[platformdirs](https://github.com/tox-dev/platformdirs) is an active fork of the deprecated appdirs. See the notice on top of the README: https://github.com/ActiveState/appdirs It has essentially the same API.

Note: platformdirs was already in the `poetry.lock` file as dependency of `tox`, so only the group changed.