### PR TITLE
Use cookies to circumvent YT bot detection

### DIFF
--- a/src/usdb_syncer/constants.py
+++ b/src/usdb_syncer/constants.py
@@ -113,6 +113,7 @@ class YtErrorMsg:
     YT_FORBIDDEN = "HTTP Error 403: Forbidden"
     YT_PREMIUM_ONLY = "This video is only available to Music Premium members"
     VM_UNAUTHENTICATED = "You're trying to use an unauthenticated request"
+    YT_CONFIRM_NOT_BOT = "Sign in to confirm you’re not a bot."
 
 
 SUPPORTED_VIDEO_SOURCES_REGEX = re.compile(

--- a/src/usdb_syncer/resource_dl.py
+++ b/src/usdb_syncer/resource_dl.py
@@ -187,7 +187,7 @@ def _download_resource(
             logger.debug(f"Failed to download '{url}': {error_message}")
             if any(
                 msg in error_message
-                for msg in (YtErrorMsg.YT_AGE_RESTRICTED, YtErrorMsg.VM_UNAUTHENTICATED)
+                for msg in (YtErrorMsg.YT_AGE_RESTRICTED, YtErrorMsg.VM_UNAUTHENTICATED, YtErrorMsg.YT_CONFIRM_NOT_BOT)
             ):
                 dl_result = _retry_with_cookies(url, options, logger)
                 return ResourceDLResult(extension=dl_result.extension)


### PR DESCRIPTION
When downloading a lot of videos from YouTube, it will ask for confirmation that we are not a bot. Currently, the error is not handled by usdb_syncer and cookies are not passed. This PR fixes the issue.