### PR TITLE
Fix crash on linux bundles

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.description="A container to build linux binaries 
 LABEL org.opencontainers.image.licenses="MIT"
 
 RUN yum update -y && yum groupinstall 'Development Tools' -y && yum install wget -y && wget https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tgz && tar -xvf Python-3.12.9.tgz
-RUN yum install libxcb libxkbcommon libxkbcommon-x11 xcb-util xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm xcb-util-cursor libva mesa-libGLU libX11 libXext libXrender mesa-libGL openssl-devel bzip2-devel libffi-devel sqlite-devel portaudio-devel -y && cd Python-3.12.9 && ./configure --enable-optimizations --enable-shared && make && make install
+RUN yum install libxcb libxkbcommon libxkbcommon-x11 xcb-util xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm xcb-util-cursor libva mesa-libGLU libX11 libXext libXrender mesa-libGL openssl-devel bzip2-devel libffi-devel sqlite-devel -y && cd Python-3.12.9 && ./configure --enable-optimizations --enable-shared && make && make install
 RUN rm -rf /Python-3.12.9 && rm -rf Python-3.12.9.tgz
 
 RUN ldconfig /usr/local/lib && ln -sf /usr/local/bin/python3.12 /usr/bin/python3.12 && ln -sf /usr/local/bin/pip3.12 /usr/bin/pip3.12 &&  ln -sf /usr/local/bin/python3.12 /usr/bin/python3 &&  ln -sf /usr/local/bin/pip3.12 /usr/bin/pip3 &&  ln -sf /usr/local/bin/python3.12 /usr/bin/python && ln -sf /usr/local/bin/pip3.12 /usr/bin/pip


### PR DESCRIPTION
I accidentally kept portaudio-devel as a dependency, which confuses pyinstaller and subsequently leads to crashes on some distros. With this change, the dockerfile truly matches the original release yaml.