### PR TITLE
Add portaudio to bundle

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -9,7 +9,7 @@ LABEL org.opencontainers.image.description="A container to build linux binaries 
 LABEL org.opencontainers.image.licenses="MIT"
 
 RUN yum update -y && yum groupinstall 'Development Tools' -y && yum install wget -y && wget https://www.python.org/ftp/python/3.12.9/Python-3.12.9.tgz && tar -xvf Python-3.12.9.tgz
-RUN yum install libxcb libxkbcommon libxkbcommon-x11 xcb-util xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm xcb-util-cursor libva mesa-libGLU libX11 libXext libXrender mesa-libGL openssl-devel bzip2-devel libffi-devel sqlite-devel -y && cd Python-3.12.9 && ./configure --enable-optimizations --enable-shared && make && make install
+RUN yum install libxcb libxkbcommon libxkbcommon-x11 xcb-util xcb-util-image xcb-util-keysyms xcb-util-renderutil xcb-util-wm xcb-util-cursor libva mesa-libGLU libX11 libXext libXrender mesa-libGL openssl-devel bzip2-devel libffi-devel sqlite-devel portaudio -y && cd Python-3.12.9 && ./configure --enable-optimizations --enable-shared && make && make install
 RUN rm -rf /Python-3.12.9 && rm -rf Python-3.12.9.tgz
 
 RUN ldconfig /usr/local/lib && ln -sf /usr/local/bin/python3.12 /usr/bin/python3.12 && ln -sf /usr/local/bin/pip3.12 /usr/bin/pip3.12 &&  ln -sf /usr/local/bin/python3.12 /usr/bin/python3 &&  ln -sf /usr/local/bin/pip3.12 /usr/bin/pip3 &&  ln -sf /usr/local/bin/python3.12 /usr/bin/python && ln -sf /usr/local/bin/pip3.12 /usr/bin/pip


### PR DESCRIPTION
Came up in #525 

<img width="628" height="38" alt="image" src="https://github.com/user-attachments/assets/e7803e08-77e4-4798-88d0-76ea26a0ae61" />

We are missing portaudio in our linux bundle process. This meant that the bundle tried to search for portaudio in the system, which leads to dependency hell when that portaudio itself tries to load libraries.

Wheel users will still have to install portaudio manually.