### PR TITLE
Fix PyPi upload

### DIFF
--- a/.github/workflows/linux_distro_testing.yaml
+++ b/.github/workflows/linux_distro_testing.yaml
@@ -215,6 +215,7 @@ jobs:
       - uses: actions/download-artifact@v7
         with:
           name: wheel
+          path: dist/
       - name: Upload to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
Place the wheel in `dist/`, which is where `gh-action-pypi-publish` should hopefully pick it up. No way to test without merging unfortunately.