### PR TITLE
Windows installer now deletes old files before copying on update.

### DIFF
--- a/installer/wininstaller.iss
+++ b/installer/wininstaller.iss
@@ -60,3 +60,7 @@ Name: "{autodesktop}\USDB Syncer"; Filename: "{app}\{#BundleName}.exe"; Tasks: d
 
 [Run]
 Filename: "{app}\{#BundleName}.exe"; Description: "{cm:LaunchProgram,USDB Syncer}"; Flags: nowait postinstall skipifsilent
+
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\_internal"
+Type: files; Name: "{app}\USDB_Syncer-*-Windows-install.exe"


### PR DESCRIPTION
Windows installer now deletes old files before copying on update.

https://jrsoftware.org/ishelp/index.php?topic=installdeletesection

Resolves https://github.com/bohning/usdb_syncer/issues/534

I messed up the old branch, which led to accidentally deleting it, so this is the same thing.