### PR TITLE
Fix wheel tests

### DIFF
--- a/.github/workflows/linux_distro_testing.yaml
+++ b/.github/workflows/linux_distro_testing.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  PYTHON_VERSION: "3.14.2"
+  PYTHON_VERSION: "3.14"
 
 jobs:
   wheel:
@@ -56,6 +56,7 @@ jobs:
           fetch-depth: 0
       - uses: astral-sh/setup-uv@v7
         with:
+          python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
       - run: uv run --no-dev --group bundle python -m tools.generate_pyside_files
       - run: uv run --no-dev --group bundle python -m tools.bundle Linux --version TestBuild
@@ -159,14 +160,14 @@ jobs:
         if: matrix.image != 'debian:12' && matrix.image != 'ubuntu:22.04' # debian:12 and ubuntu:22.04 are too old for setup-python (https://github.com/actions/setup-python/issues/1224)
         uses: actions/setup-python@v6
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: '>=3.11 <3.15'
       - name: Install python3.11 (for debian:12)
         if: matrix.image == 'debian:12'
         run: |
           apt update
           apt install -y python3 python3-venv python3-pip
           ln -s $(which python3) /usr/local/bin/python
-      - name: Install python3.12 (for ubuntu:22.04) using deadsnakes PPA.
+      - name: Install python3.14 (for ubuntu:22.04) using deadsnakes PPA.
         if: matrix.image == 'ubuntu:22.04'
         run: |
           apt update

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ on:
         type: boolean
 
 env:
-  PYTHON_VERSION: "3.14.2"
+  PYTHON_VERSION: "3.14"
 
 jobs:
   scrape-song-list:
@@ -58,6 +58,8 @@ jobs:
             TARGET: Windows-portable
           - os: windows-latest
             TARGET: Windows-install
+    env:
+      UV_PYTHON_DOWNLOADS: "never"
     steps:
       - uses: actions/checkout@v6
         with:
@@ -70,6 +72,9 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
       - name: Set up uv
         uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          python-version: ${{ env.PYTHON_VERSION }}
       - name: Set macOS deployment target (macOS 12+ compatibility)
         if: startsWith(matrix.os, 'macos')
         run: echo "MACOSX_DEPLOYMENT_TARGET=12.0" >> $GITHUB_ENV


### PR DESCRIPTION
<img width="931" height="59" alt="image" src="https://github.com/user-attachments/assets/070fc757-5d89-46f7-af12-83c8b048fb26" />


Fix a test I broke. Didn't expect `actions/setup-python` to not have some versions. Now the constraint is '>=3.11 <3.15'. We expect the wheels to be compatible with all those versions after all.