### PR TITLE
Remove defusedxml as hidden-import.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 ## Fixes
 
 - Disable ffmpeg-normalize progress bar for bundles.
-- Fix macOS bundles by including defusedxml as hidden-import.
 
 <!-- 0.22.1 -->
 
@@ -13,7 +12,7 @@
 
 ## Fixes
 
-- ffmpeg version extraction fixed for Linux.
+- Robustied ffmpeg version extraction, which could crash the application on start.
 - Fixed retrieving file paths from settings, which would crash the application on start.
 
 <!-- 0.22.0 -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ## Fixes
 
-- Robustied ffmpeg version extraction, which could crash the application on start.
+- Robustified ffmpeg version extraction, which could crash the application on start.
 - Fixed retrieving file paths from settings, which would crash the application on start.
 
 <!-- 0.22.0 -->

--- a/src/tools/bundle.py
+++ b/src/tools/bundle.py
@@ -61,7 +61,6 @@ def bundle(platform: OS, version: str, with_songlist: bool = False) -> None:
     # fmt: off
     args: list[str] = [
         "--exclude-module", "_tkinter",
-        "--hidden-import", "defusedxml",
         "--copy-metadata", "yt-dlp",
         "--copy-metadata", "deno",
         "--add-data", "licenses:usdb_syncer/data/licenses",


### PR DESCRIPTION
defusedxml is the dependency of ttml2us addon, which prevented the start of the bundle on macOS. It is not solved by adding it to the bundle.